### PR TITLE
Backend Authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ COPY . .
 
 RUN yarn --modules-folder=/opt/node_modules
 
-
 # yarn ignores its own config (--modules-folder); symlink node_modules where it expects
 # https://github.com/yarnpkg/yarn/issues/3900
 CMD ln -fs /opt/node_modules && yarn start

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -8,6 +8,5 @@ RUN yarn
 
 RUN yarn build
 
-
 FROM httpd:2.4
 COPY --from=build-deps /opt/app/build /usr/local/apache2/htdocs/

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,0 +1,13 @@
+FROM node:10 as build-deps
+
+WORKDIR /opt/app
+
+COPY . .
+
+RUN yarn
+
+RUN yarn build
+
+
+FROM httpd:2.4
+COPY --from=build-deps /opt/app/build /usr/local/apache2/htdocs/

--- a/default.env
+++ b/default.env
@@ -1,0 +1,12 @@
+# original defaults
+PORT=8000
+REACT_APP_EPIC_SUPPORTED_QUERIES=false
+
+
+# confidential backend API endpoint
+REACT_APP_CONF_API_URL=http://localhost:5000
+
+# Uncomment to build production docker image
+#FRONTEND_DOCKERFILE=Dockerfile.production
+# Override when using apache to serve in production
+#T_PORT=80

--- a/default.env
+++ b/default.env
@@ -4,7 +4,8 @@ REACT_APP_EPIC_SUPPORTED_QUERIES=false
 
 
 # confidential backend API endpoint
-REACT_APP_CONF_API_URL=http://localhost:5000
+# NB: domain is required for cookies to be set
+REACT_APP_CONF_API_URL=http://localtest.me:5000
 
 # Uncomment to build production docker image
 #FRONTEND_DOCKERFILE=Dockerfile.production

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,9 +4,10 @@ services:
   frontend:
     build:
       context: .
-      dockerfile: Dockerfile.production
+      dockerfile: ${FRONTEND_DOCKERFILE:-Dockerfile}
     ports:
-      - 8000:80
+      # allow override of target and published port
+      - ${P_PORT:-8000}:${T_PORT:-8000}
     volumes:
       - ./:/opt/app
     env_file:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,4 +10,5 @@ services:
     volumes:
       - ./:/opt/app
     env_file:
-      - frontend.env
+      # Reuse .env from CRA
+      - .env

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,8 +4,9 @@ services:
   frontend:
     build:
       context: .
+      dockerfile: Dockerfile.production
     ports:
-      - 8000:8000
+      - 8000:80
     volumes:
       - ./:/opt/app
     env_file:

--- a/frontend.env.default
+++ b/frontend.env.default
@@ -1,2 +1,0 @@
-# confidential back-end API endpoint
-# REACT_APP_CONF_API_URL=

--- a/src/launch.js
+++ b/src/launch.js
@@ -1,6 +1,9 @@
 import FHIR from 'fhirclient';
 
-fetch(`${process.env.PUBLIC_URL}/launch-context.json`)
+fetch(`${process.env.REACT_APP_CONF_API_URL}/auth/auth-info`, {
+  // include cookies in request
+  credentials: 'include'
+})
   .then((response)      => response.json())
   .then((launchContext) => FHIR.oauth2.authorize(launchContext))
   .catch((error)        => console.error(error));

--- a/src/launch.js
+++ b/src/launch.js
@@ -1,6 +1,12 @@
 import FHIR from 'fhirclient';
 
-fetch(`${process.env.REACT_APP_CONF_API_URL}/auth/auth-info`, {
+// retrieve launch context from backend, if configured
+let context_url = `${process.env.PUBLIC_URL}/launch-context.json`;
+if (process.env.REACT_APP_CONF_API_URL){
+  context_url = `${process.env.REACT_APP_CONF_API_URL}/auth/auth-info`;
+}
+
+fetch(context_url, {
   // include cookies in request
   credentials: 'include'
 })


### PR DESCRIPTION
* Read launch context (and `fakeTokenResponse`) from back-end, if configured
* Move docker configuration into `.env` 
  * NB: values in `frontend.env` must be moved to `.env`
* Add production Dockerfile
