### PR TITLE
add error display when loading external data, e.g. PDMP data failed

### DIFF
--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -28,7 +28,8 @@ export default class Landing extends Component {
       result: null,
       loading: true,
       collector: [],
-      externals: {}
+      externals: {},
+      loadDataErrorMessagesList: []
     };
 
     this.tocInitialized = false;
@@ -44,13 +45,13 @@ export default class Landing extends Component {
         result['Summary'] = {...result['Summary'], ...response[1]};
         result['Summary']['PatientEducationMaterials'] = patientEducationReferences;
         const { sectionFlags, flaggedCount } = this.processSummary(result.Summary);
-        this.setState({ loading: false });
+        this.setState({ loading: false});
         this.setState({ result, sectionFlags, flaggedCount });
       }
     )
     .catch((err) => {
       console.error(err);
-      this.setState({ loading: false });
+      this.setState({ loading: false});
     });
   }
 
@@ -200,6 +201,11 @@ export default class Landing extends Component {
       timeoutPromise
     ]).catch(e => {
       console.log(`Error fetching data from ${datasetKey}: ${e}`);
+      this.setState(state => {
+        const list = state.loadDataErrorMessagesList;
+        list.push(`Error fetching data from ${datasetKey}: ${e}`);
+        return {loadDataErrorMessagesList: list};
+      });
       dataSet[datasetKey] = null;
       return dataSet;
     });
@@ -382,6 +388,7 @@ export default class Landing extends Component {
           numRiskEntries={numRiskEntries}
           numNonPharTreatmentEntries={numNonPharTreatmentEntries}
           numPDMPDataEntries={numPDMPDataEntries}
+          errorMessagesList={this.state.loadDataErrorMessagesList}
         />
       </div>
     );

--- a/src/components/Summary.js
+++ b/src/components/Summary.js
@@ -360,7 +360,7 @@ export default class Summary extends Component {
   };
 
   render() {
-    const { summary, collector, result } = this.props;
+    const { summary, collector, result, errorMessagesList } = this.props;
     const meetsInclusionCriteria = summary.Patient.MeetsInclusionCriteria;
     if (!summary) { return null; }
 
@@ -402,12 +402,18 @@ export default class Summary extends Component {
             </div>
           }
 
-          <div class="legend">
+          <div className="error">{
+            errorMessagesList.map((item, key) => {
+              return (<div key={key}>{item}</div>);
+            })
+          }</div>
+
+          <div className="legend">
             <div>
-              <span class="icon orange"></span>CDC guidelines in accordance with Washington State guideline
+              <span className="icon orange"></span>CDC guidelines in accordance with Washington State guideline
             </div>
             <div>
-              <span class="icon red"></span>Washington State guideline exclusively
+              <span className="icon red"></span>Washington State guideline exclusively
             </div>
           </div>
 
@@ -463,5 +469,6 @@ Summary.propTypes = {
   numTreatmentsEntries: PropTypes.number.isRequired,
   numRiskEntries: PropTypes.number.isRequired,
   numNonPharTreatmentEntries: PropTypes.number.isRequired,
-  numPDMPDataEntries: PropTypes.number.isRequired
+  numPDMPDataEntries: PropTypes.number.isRequired,
+  errorMessagesList: PropTypes.array
 };

--- a/src/styles/components/_Summary.scss
+++ b/src/styles/components/_Summary.scss
@@ -2,6 +2,13 @@
   display: flex;
   min-height: calc(100vh - 100px);
 
+  .error {
+    color: $color-red-darker;
+    font-weight: 600;
+    margin-left: 36px;
+    margin-bottom: 24px;
+  }
+
   &__nav {
     color: $color-white;
     padding: 38px 0 20px;

--- a/src/styles/elements/_variables.scss
+++ b/src/styles/elements/_variables.scss
@@ -2,7 +2,8 @@
 $color-body: #39373d;
 $color-black: #37404e;
 $color-white: #fff;
-$color-blue: #449ba7;
+//$color-blue: #449ba7;
+$color-blue: #217684;
 $color-gray-dark: #64707e;
 $color-gray: #6a797e;
 $color-gray-light: #6a7888;
@@ -11,6 +12,7 @@ $color-gray-lightest: #f5f8fb;
 $color-yellow: #f8c855;
 $color-red: #ecacac;
 $color-red-dark: #e67171;
+$color-red-darker: #a75454;
 $color-orange: #ab4317;
 $color-orange-light: #e09b1d;
 $color-beige: #f9f3e3;


### PR DESCRIPTION
address trello card titled "Distinguish when PDMP query yields no results, vs when it's broken"

Changes include:
adding error display when request to get external data failed
also address React warning regarding naming of 'class' attribute - fixed to name 'className'