### PR TITLE
fix parsing of response stream

### DIFF
--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -226,13 +226,17 @@ export default class Landing extends Component {
     let json = null;
     if (results) {
       try {
-        json = JSON.parse(results);
+        //read response stream
+        json = await (results.json()).catch(e => {
+          console.log(`Error parsing ${datasetKey} response json: ${e.message}`);
+          this.setDataError(datasetKey, `There was error parsing data: ${e.message}`);
+        });
       } catch(e) {
         this.setDataError(datasetKey, `There was error parsing data: ${e}`);
         json = null;
       }
     }
-    
+
     if (!json) {
       let demoData = this.getDemoData(datasetKey);
       //if unable to fetch data, set data to demo data if any


### PR DESCRIPTION
Found a bug where demo data is presented even when PDMP endpoint is returning legitimate data.

Fix is to read response stream into a JSON object (JSON.parse does not work on a Response object).
