### PR TITLE
use react polyfill library, remote dependency on deprecated babel polyfill library

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Pain Management Factors SMART-on-FHIR App",
   "license": "Apache-2.0",
   "dependencies": {
-    "@babel/polyfill": "^7.8.3",
     "@fortawesome/fontawesome-svg-core": "^1.2.26",
     "@fortawesome/free-solid-svg-icons": "^5.12.0",
     "@fortawesome/react-fontawesome": "^0.1.8",
@@ -60,13 +59,15 @@
       ">0.2%",
       "not dead",
       "not op_mini all",
-      "ie 11"
+      "ie 11",
+      "edge >= 12"
     ],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",
       "last 1 safari version",
-      "ie 11"
+      "ie 11",
+      "edge >= 12"
     ]
   },
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import '@babel/polyfill';
+import 'react-app-polyfill/ie11';
+import 'react-app-polyfill/stable';
 import React from 'react';
 import { render } from 'react-dom';
 import { BrowserRouter as Router } from 'react-router-dom';


### PR DESCRIPTION
address @babel/polyfill deprecation warning - remove dependency on deprecated @babel/polyfill library and use react-app-polyfill libraries instead

[Launch URL](https://deploy-preview-35--distracted-jepsen-bc9c39.netlify.app/launch?launch=eyJhIjoiMSIsImIiOiI0MTcwMiJ9&iss=https%3A%2F%2Fsmart-dev-sandbox-launcher.cirg.washington.edu%2Fv%2Fr2%2Ffhir)
