### PR TITLE
env variables retrieval, medication list bug fix and patient id updates

### DIFF
--- a/public/assets/data/PDMPDemoData.json
+++ b/public/assets/data/PDMPDemoData.json
@@ -6,7 +6,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -18,19 +18,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "65162062750", 
-              "display": "TRAMADOL HCL 50 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "TRAMADOL HCL 50 MG TABLET"
-        }
-      },
+        "coding": [
+          {
+            "code": "65162062750", 
+            "display": "TRAMADOL HCL 50 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "TRAMADOL HCL 50 MG TABLET"
+      }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "TEST TEST"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -40,7 +38,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "CVS Pharmacy"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -52,19 +50,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "00591024110", 
-              "display": "LORAZEPAM 1 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "LORAZEPAM 1 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "00591024110", 
+            "display": "LORAZEPAM 1 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "LORAZEPAM 1 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Lee Kramer"
+        "display": "TEST TEST"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -74,7 +70,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Bartell Drug Pharmacy"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -86,19 +82,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "16714062202", 
-              "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "16714062202", 
+            "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Elizabeth Morgan"
+        "display": "TEST PRESCRIBER"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -108,7 +102,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "UW Medicine Pharmacy"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -120,19 +114,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "16714062201", 
-              "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "16714062201", 
+            "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "HID TEST PRESCRIBER"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -142,7 +134,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -154,19 +146,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "00406577101", 
-              "display": "METHADONE HCL 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "METHADONE HCL 10 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "00406577101", 
+            "display": "METHADONE HCL 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "METHADONE HCL 10 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Lynette Scholl"
+        "display": "TEST TEST"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -176,7 +166,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -188,19 +178,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "00406577101", 
-              "display": "METHADONE HCL 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "METHADONE HCL 10 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "00406577101", 
+            "display": "METHADONE HCL 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "METHADONE HCL 10 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Christopher Fletcher"
+        "display": "TEST TEST"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -210,7 +198,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "CVS Pharmacy"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -222,19 +210,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "00406577101", 
-              "display": "METHADONE HCL 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "METHADONE HCL 10 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "00406577101", 
+            "display": "METHADONE HCL 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "METHADONE HCL 10 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "TEST TEST"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -244,7 +230,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -256,19 +242,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "00002254902", 
-              "display": "MORPHINE 10 MG SOLUBLE TAB", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "MORPHINE 10 MG SOLUBLE TAB"
-        }
+        "coding": [
+          {
+            "code": "00002254902", 
+            "display": "MORPHINE 10 MG SOLUBLE TAB", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "MORPHINE 10 MG SOLUBLE TAB"
       }, 
       "prescriber": {
-        "display": "Robert Wagner"
+        "display": "TEST PRESCRIBER"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -278,7 +262,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "UW Medicine Pharmacy"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -290,19 +274,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "00009041701", 
-              "display": "DEPO-TESTOSTERONE 200 MG/ML", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "DEPO-TESTOSTERONE 200 MG/ML"
-        }
+        "coding": [
+          {
+            "code": "00009041701", 
+            "display": "DEPO-TESTOSTERONE 200 MG/ML", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "DEPO-TESTOSTERONE 200 MG/ML"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "HID PRESCRIBER"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -312,7 +294,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -324,19 +306,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "63187006320", 
-              "display": "TRAMADOL HCL 50 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "TRAMADOL HCL 50 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "63187006320", 
+            "display": "TRAMADOL HCL 50 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "TRAMADOL HCL 50 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "TEST PRESCRIBER"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -346,7 +326,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -358,19 +338,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "16714062202", 
-              "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "16714062202", 
+            "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Jose Mantilla"
+        "display": "HID PRESCRIBER"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -380,7 +358,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "UW Medicine Pharmacy"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -392,19 +370,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "00009041701", 
-              "display": "DEPO-TESTOSTERONE 200 MG/ML", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "DEPO-TESTOSTERONE 200 MG/ML"
-        }
+        "coding": [
+          {
+            "code": "00009041701", 
+            "display": "DEPO-TESTOSTERONE 200 MG/ML", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "DEPO-TESTOSTERONE 200 MG/ML"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "HID PRESCRIBER"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -414,7 +390,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -426,19 +402,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "16714062202", 
-              "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "16714062202", 
+            "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "HID PRESCRIBER"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -448,7 +422,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -460,19 +434,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "00009041701", 
-              "display": "DEPO-TESTOSTERONE 200 MG/ML", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "DEPO-TESTOSTERONE 200 MG/ML"
-        }
+        "coding": [
+          {
+            "code": "00009041701", 
+            "display": "DEPO-TESTOSTERONE 200 MG/ML", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "DEPO-TESTOSTERONE 200 MG/ML"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "HID PRESCRIBER"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -482,7 +454,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -494,19 +466,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "16714062202", 
-              "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "16714062202", 
+            "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "HID PRESCRIBER"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -516,7 +486,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -528,19 +498,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "16714062202", 
-              "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "16714062202", 
+            "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "HID PRESCRIBER"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -550,7 +518,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -562,19 +530,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "00406577101", 
-              "display": "METHADONE HCL 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "METHADONE HCL 10 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "00406577101", 
+            "display": "METHADONE HCL 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "METHADONE HCL 10 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "TEST TEST"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -584,7 +550,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -596,19 +562,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "16714062202", 
-              "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "16714062202", 
+            "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "HID PRESCRIBER"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -618,7 +582,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -630,19 +594,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "16714062202", 
-              "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "16714062202", 
+            "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "HID PRESCRIBER"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -652,7 +614,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -664,19 +626,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "00406577101", 
-              "display": "METHADONE HCL 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "METHADONE HCL 10 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "00406577101", 
+            "display": "METHADONE HCL 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "METHADONE HCL 10 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "TEST TEST"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -686,7 +646,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -698,19 +658,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "16714062202", 
-              "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "16714062202", 
+            "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "HID TEST PRESCRIBER"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -720,7 +678,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -732,19 +690,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "00406577101", 
-              "display": "METHADONE HCL 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "METHADONE HCL 10 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "00406577101", 
+            "display": "METHADONE HCL 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "METHADONE HCL 10 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "TEST PRESCRIBER"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -754,7 +710,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -766,19 +722,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "12496120803", 
-              "display": "SUBOXONE 8 MG-2 MG SL FILM", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "SUBOXONE 8 MG-2 MG SL FILM"
-        }
+        "coding": [
+          {
+            "code": "12496120803", 
+            "display": "SUBOXONE 8 MG-2 MG SL FILM", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "SUBOXONE 8 MG-2 MG SL FILM"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "TEST PRESCRIBER"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -788,7 +742,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -800,19 +754,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "00093005801", 
-              "display": "TRAMADOL HCL 50 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "TRAMADOL HCL 50 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "00093005801", 
+            "display": "TRAMADOL HCL 50 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "TRAMADOL HCL 50 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "TEST PRESCRIBER"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -822,7 +774,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -834,19 +786,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "63187006320", 
-              "display": "TRAMADOL HCL 50 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "TRAMADOL HCL 50 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "63187006320", 
+            "display": "TRAMADOL HCL 50 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "TRAMADOL HCL 50 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "TEST PRESCRIBER"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -856,7 +806,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -868,19 +818,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "00002254902", 
-              "display": "MORPHINE 10 MG SOLUBLE TAB", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "MORPHINE 10 MG SOLUBLE TAB"
-        }
+        "coding": [
+          {
+            "code": "00002254902", 
+            "display": "MORPHINE 10 MG SOLUBLE TAB", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "MORPHINE 10 MG SOLUBLE TAB"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "TEST PRESCRIBER"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -890,7 +838,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -902,19 +850,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "00406577101", 
-              "display": "METHADONE HCL 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "METHADONE HCL 10 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "00406577101", 
+            "display": "METHADONE HCL 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "METHADONE HCL 10 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "TEST TEST"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -924,7 +870,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -936,19 +882,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "00406577101", 
-              "display": "METHADONE HCL 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "METHADONE HCL 10 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "00406577101", 
+            "display": "METHADONE HCL 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "METHADONE HCL 10 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "TEST TEST"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -958,7 +902,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -970,19 +914,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "00406577101", 
-              "display": "METHADONE HCL 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "METHADONE HCL 10 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "00406577101", 
+            "display": "METHADONE HCL 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "METHADONE HCL 10 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "TEST TEST"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -992,7 +934,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -1004,19 +946,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "00406577101", 
-              "display": "METHADONE HCL 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "METHADONE HCL 10 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "00406577101", 
+            "display": "METHADONE HCL 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "METHADONE HCL 10 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "TEST TEST"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -1026,7 +966,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -1038,19 +978,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "00406577101", 
-              "display": "METHADONE HCL 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "METHADONE HCL 10 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "00406577101", 
+            "display": "METHADONE HCL 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "METHADONE HCL 10 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "TEST TEST"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -1060,7 +998,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -1072,19 +1010,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "00406577101", 
-              "display": "METHADONE HCL 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "METHADONE HCL 10 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "00406577101", 
+            "display": "METHADONE HCL 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "METHADONE HCL 10 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "TEST TEST"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -1094,7 +1030,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -1106,155 +1042,17 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "00406577101", 
-              "display": "METHADONE HCL 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "METHADONE HCL 10 MG TABLET"
-        }
-      }, 
-      "prescriber": {
-        "display": "Eleanor Chen"
-      }, 
-      "resourceType": "MedicationOrder"
-    }, 
-    {
-      "dateWritten": "2019-04-25", 
-      "dispenseRequest": {
-        "extension": [
+        "coding": [
           {
-            "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
-          }, 
-          {
-            "url": "http://cosri.org/fhir/last_fill", 
-            "valueDate": "2019-04-25"
+            "code": "00406577101", 
+            "display": "METHADONE HCL 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
           }
         ], 
-        "quantity": {
-          "value": 10
-        }
-      }, 
-      "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "16714062202", 
-              "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
-        }
+        "text": "METHADONE HCL 10 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
-      }, 
-      "resourceType": "MedicationOrder"
-    }, 
-    {
-      "dateWritten": "2019-01-01", 
-      "dispenseRequest": {
-        "extension": [
-          {
-            "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
-          }, 
-          {
-            "url": "http://cosri.org/fhir/last_fill", 
-            "valueDate": "2019-01-01"
-          }
-        ], 
-        "quantity": {
-          "value": 10
-        }
-      }, 
-      "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "16714062202", 
-              "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
-        }
-      }, 
-      "prescriber": {
-        "display": "Eleanor Chen"
-      }, 
-      "resourceType": "MedicationOrder"
-    }, 
-    {
-      "dateWritten": "2019-04-01", 
-      "dispenseRequest": {
-        "extension": [
-          {
-            "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
-          }, 
-          {
-            "url": "http://cosri.org/fhir/last_fill", 
-            "valueDate": "2019-04-01"
-          }
-        ], 
-        "quantity": {
-          "value": 1
-        }
-      }, 
-      "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "00406577101", 
-              "display": "METHADONE HCL 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "METHADONE HCL 10 MG TABLET"
-        }
-      },
-      "prescriber": {
-        "display": "Eleanor Chen"
-      }, 
-      "resourceType": "MedicationOrder"
-    }, 
-    {
-      "dateWritten": "2019-02-24", 
-      "dispenseRequest": {
-        "extension": [
-          {
-            "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
-          }, 
-          {
-            "url": "http://cosri.org/fhir/last_fill", 
-            "valueDate": "2019-02-24"
-          }
-        ], 
-        "quantity": {
-          "value": 5
-        }
-      }, 
-      "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "16714062202", 
-              "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
-        }
-      }, 
-      "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "TEST TEST"
       }, 
       "resourceType": "MedicationOrder"
     }, 
@@ -1264,7 +1062,7 @@
         "extension": [
           {
             "url": "http://cosri.org/fhir/pharmacy_name", 
-            "valueString": "Walgreens"
+            "valueString": "TEST, DOCTOR"
           }, 
           {
             "url": "http://cosri.org/fhir/last_fill", 
@@ -1276,19 +1074,145 @@
         }
       }, 
       "medicationCodeableConcept": {
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "code": "16714062201", 
-              "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
-              "system": "http://hl7.org/fhir/sid/ndc"
-            }
-          ], 
-          "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
-        }
+        "coding": [
+          {
+            "code": "16714062201", 
+            "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
       }, 
       "prescriber": {
-        "display": "Eleanor Chen"
+        "display": "TEST PRESCRIBER"
+      }, 
+      "resourceType": "MedicationOrder"
+    }, 
+    {
+      "dateWritten": "2019-02-24", 
+      "dispenseRequest": {
+        "extension": [
+          {
+            "url": "http://cosri.org/fhir/pharmacy_name", 
+            "valueString": "TEST, DOCTOR"
+          }, 
+          {
+            "url": "http://cosri.org/fhir/last_fill", 
+            "valueDate": "2019-02-24"
+          }
+        ], 
+        "quantity": {
+          "value": 5
+        }
+      }, 
+      "medicationCodeableConcept": {
+        "coding": [
+          {
+            "code": "16714062202", 
+            "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
+      }, 
+      "prescriber": {
+        "display": "HID PRESCRIBER"
+      }, 
+      "resourceType": "MedicationOrder"
+    }, 
+    {
+      "dateWritten": "2019-04-01", 
+      "dispenseRequest": {
+        "extension": [
+          {
+            "url": "http://cosri.org/fhir/pharmacy_name", 
+            "valueString": "TEST, DOCTOR"
+          }, 
+          {
+            "url": "http://cosri.org/fhir/last_fill", 
+            "valueDate": "2019-04-01"
+          }
+        ], 
+        "quantity": {
+          "value": 1
+        }
+      }, 
+      "medicationCodeableConcept": {
+        "coding": [
+          {
+            "code": "00406577101", 
+            "display": "METHADONE HCL 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "METHADONE HCL 10 MG TABLET"
+      }, 
+      "prescriber": {
+        "display": "TEST TEST"
+      }, 
+      "resourceType": "MedicationOrder"
+    }, 
+    {
+      "dateWritten": "2019-01-01", 
+      "dispenseRequest": {
+        "extension": [
+          {
+            "url": "http://cosri.org/fhir/pharmacy_name", 
+            "valueString": "TEST, DOCTOR"
+          }, 
+          {
+            "url": "http://cosri.org/fhir/last_fill", 
+            "valueDate": "2019-01-01"
+          }
+        ], 
+        "quantity": {
+          "value": 10
+        }
+      }, 
+      "medicationCodeableConcept": {
+        "coding": [
+          {
+            "code": "16714062202", 
+            "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
+      }, 
+      "prescriber": {
+        "display": "HID PRESCRIBER"
+      }, 
+      "resourceType": "MedicationOrder"
+    }, 
+    {
+      "dateWritten": "2019-04-25", 
+      "dispenseRequest": {
+        "extension": [
+          {
+            "url": "http://cosri.org/fhir/pharmacy_name", 
+            "valueString": "TEST, DOCTOR"
+          }, 
+          {
+            "url": "http://cosri.org/fhir/last_fill", 
+            "valueDate": "2019-04-25"
+          }
+        ], 
+        "quantity": {
+          "value": 10
+        }
+      }, 
+      "medicationCodeableConcept": {
+        "coding": [
+          {
+            "code": "16714062202", 
+            "display": "ZOLPIDEM TARTRATE 10 MG TABLET", 
+            "system": "http://hl7.org/fhir/sid/ndc"
+          }
+        ], 
+        "text": "ZOLPIDEM TARTRATE 10 MG TABLET"
+      }, 
+      "prescriber": {
+        "display": "HID PRESCRIBER"
       }, 
       "resourceType": "MedicationOrder"
     }

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -27,10 +27,21 @@ export default class Landing extends Component {
       result: null,
       loading: true,
       collector: [],
-      externals: {}
+      externals: {},
+      patientId: ""
     };
 
     this.tocInitialized = false;
+  }
+
+  setPatientId() {
+    if (!this.state.collector) return;
+    let patientBundle = (this.state.collector).filter(item => item.data && item.data.resourceType.toLowerCase() === "patient");
+    if (patientBundle.length) {
+      this.setState({
+        patientId: patientBundle[0].data.id
+      });
+    }
   }
 
   componentDidMount() {
@@ -38,24 +49,57 @@ export default class Landing extends Component {
      * fetch env data where necessary, i.e. env.json, to ensure REACT env variables are available
      */
     fetchEnvData();
-    Promise.all([executeElm(this.state.collector), this.getExternalData()])
+    // Promise.all([executeElm(this.state.collector), this.getExternalData()])
+    // .then(
+    //   response => {
+    //     //set result from data from EPIC
+    //     let result = response[0];
+    //     //add data from other sources, e.g. PDMP
+    //     result['Summary'] = {...result['Summary'], ...response[1]};
+    //     const { sectionFlags, flaggedCount } = this.processSummary(result.Summary);
+
+    //     this.processOverviewData(result['Summary'], sectionFlags);
+    //     this.setState({ loading: false});
+    //     this.setState({ result, sectionFlags, flaggedCount });
+    //   }
+    // )
+    // .catch((err) => {
+    //   console.error(err);
+    //   this.setState({ loading: false});
+    // });
+    let result = {};
+    Promise.all([executeElm(this.state.collector)])
     .then(
       response => {
         //set result from data from EPIC
-        let result = response[0];
-        //add data from other sources, e.g. PDMP
-        result['Summary'] = {...result['Summary'], ...response[1]};
+        let EPICData = response[0];
+        result['Summary'] = {...EPICData['Summary']};
         const { sectionFlags, flaggedCount } = this.processSummary(result.Summary);
-
-        this.processOverviewData(result['Summary'], sectionFlags);
-        this.setState({ loading: false});
         this.setState({ result, sectionFlags, flaggedCount });
+        this.setPatientId();
+        //add data from other sources, e.g. PDMP
+        Promise.all([this.getExternalData()]).then(
+          externalData => {
+            console.log("external data? ", externalData[0]);
+            console.log("state collector? ", this.state.collector);
+            console.log("patient id? ", this.state.patientId)
+            result['Summary'] = {...result['Summary'], ...externalData[0]};
+            console.log("Result ? ", result)
+            const { sectionFlags, flaggedCount } = this.processSummary(result.Summary);
+            this.processOverviewData(result['Summary'], sectionFlags);
+            this.setState({ result, sectionFlags, flaggedCount });
+            this.setState({ loading: false});
+        }).catch((err) => {
+          console.log(err);
+          this.setState({ loading: false});
+        });
       }
     )
     .catch((err) => {
       console.error(err);
       this.setState({ loading: false});
     });
+    
   }
 
   componentDidUpdate() {
@@ -195,7 +239,8 @@ export default class Landing extends Component {
     if (!endpoint) return "";
     return (endpoint)
     .replace('{process.env.REACT_APP_CONF_API_URL}', getEnv("REACT_APP_CONF_API_URL"))
-    .replace('{process.env.PUBLIC_URL}', getEnv("PUBLIC_URL"));
+    .replace('{process.env.PUBLIC_URL}', getEnv("PUBLIC_URL"))
+    .replace('{patientId}', this.state.patientId);
   }
 
   processMedicationOrder(result, dataKey) {

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -9,7 +9,7 @@ import {datishFormat} from '../helpers/formatit';
 import {dateTimeCompare} from '../helpers/sortit';
 import summaryMap from './summary.json';
 
-import {fetchEnvData} from '../utils/envConfig';
+import {getEnv, fetchEnvData} from '../utils/envConfig';
 import Header from './Header';
 import Summary from './Summary';
 import Spinner from '../elements/Spinner';
@@ -194,8 +194,8 @@ export default class Landing extends Component {
   processEndPoint(endpoint) {
     if (!endpoint) return "";
     return (endpoint)
-    .replace('{process.env.REACT_APP_CONF_API_URL}', process.env.REACT_APP_CONF_API_URL)
-    .replace('{process.env.PUBLIC_URL}', process.env.PUBLIC_URL);
+    .replace('{process.env.REACT_APP_CONF_API_URL}', getEnv("REACT_APP_CONF_API_URL"))
+    .replace('{process.env.PUBLIC_URL}', getEnv("PUBLIC_URL"));
   }
 
   processMedicationOrder(result, dataKey) {
@@ -434,7 +434,7 @@ export default class Landing extends Component {
 
     //console.log("sectionFlags ", sectionFlags);
     // Get the configured endpoint to use for POST for app analytics
-    fetch(`${process.env.PUBLIC_URL}/config.json`)
+    fetch(`${getEnv("PUBLIC_URL")}/config.json`)
       .then(response => response.json())
       .then(config => {
         // Only provide analytics if the endpoint has been set

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -43,6 +43,9 @@ export default class Landing extends Component {
       });
     }
   }
+  getPatientId() {
+    return this.state.patientId;
+  }
 
   componentDidMount() {
     /*
@@ -80,11 +83,7 @@ export default class Landing extends Component {
         //add data from other sources, e.g. PDMP
         Promise.all([this.getExternalData()]).then(
           externalData => {
-            console.log("external data? ", externalData[0]);
-            console.log("state collector? ", this.state.collector);
-            console.log("patient id? ", this.state.patientId)
             result['Summary'] = {...result['Summary'], ...externalData[0]};
-            console.log("Result ? ", result)
             const { sectionFlags, flaggedCount } = this.processSummary(result.Summary);
             this.processOverviewData(result['Summary'], sectionFlags);
             this.setState({ result, sectionFlags, flaggedCount });
@@ -240,7 +239,7 @@ export default class Landing extends Component {
     return (endpoint)
     .replace('{process.env.REACT_APP_CONF_API_URL}', getEnv("REACT_APP_CONF_API_URL"))
     .replace('{process.env.PUBLIC_URL}', getEnv("PUBLIC_URL"))
-    .replace('{patientId}', this.state.patientId);
+    .replace('{patientId}', this.getPatientId());
   }
 
   processMedicationOrder(result, dataKey) {

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -36,6 +36,9 @@ export default class Landing extends Component {
 
   setPatientId() {
     if (!this.state.collector) return;
+    /*
+     * passed down via fhir.js
+     */
     let patientBundle = (this.state.collector).filter(item => item.data && item.data.resourceType.toLowerCase() === "patient");
     if (patientBundle.length) {
       this.setState({

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -52,24 +52,6 @@ export default class Landing extends Component {
      * fetch env data where necessary, i.e. env.json, to ensure REACT env variables are available
      */
     fetchEnvData();
-    // Promise.all([executeElm(this.state.collector), this.getExternalData()])
-    // .then(
-    //   response => {
-    //     //set result from data from EPIC
-    //     let result = response[0];
-    //     //add data from other sources, e.g. PDMP
-    //     result['Summary'] = {...result['Summary'], ...response[1]};
-    //     const { sectionFlags, flaggedCount } = this.processSummary(result.Summary);
-
-    //     this.processOverviewData(result['Summary'], sectionFlags);
-    //     this.setState({ loading: false});
-    //     this.setState({ result, sectionFlags, flaggedCount });
-    //   }
-    // )
-    // .catch((err) => {
-    //   console.error(err);
-    //   this.setState({ loading: false});
-    // });
     let result = {};
     Promise.all([executeElm(this.state.collector)])
     .then(

--- a/src/components/summary.json
+++ b/src/components/summary.json
@@ -100,7 +100,7 @@
               "Drug Description": {
                 "key": "medicationCodeableConcept",
                 "formatter": "codeableConceptFormat",
-                "formatterArguments": ["medicationCodeableConcept", "text"]
+                "formatterArguments": ["text"]
               },
               "Quantity": "_quantity",
               "Written Date": { "key": "dateWritten", "formatter": "datishFormat", "sorter": "dateTimeFormat" },

--- a/src/components/summary.json
+++ b/src/components/summary.json
@@ -66,7 +66,7 @@
     "title":"State PMP Prescriptions",
     "provenanceText": "State PMP prescriptions are queried from the state prescription monitoring program (PMP).  Dispensers may take up to X days to report prescription fills to the PMP.  An exact match between patient name and DOB is required, or no results will be returned.  It is also possible for prescriptions to be duplicated in the PMP and cross-border fills may not presented.  Historical prescription fills from the PMP go back one year from the data of the query.",
     "dataSource": {
-      "endpoint": "{process.env.REACT_APP_CONF_API_URL}/v/r2/fhir/MedicationOrder",
+      "endpoint": "{process.env.REACT_APP_CONF_API_URL}/v/r2/fhir/MedicationOrder?patient={patientId}",
       "dataKey": "PDMPMedications",
       "dataKeySource": "entry",
       "processFunction": "processMedicationOrder"

--- a/src/launch.js
+++ b/src/launch.js
@@ -1,15 +1,15 @@
 import 'react-app-polyfill/ie11';
 import 'react-app-polyfill/stable';
 import FHIR from 'fhirclient';
-import {fetchEnvData} from './utils/envConfig';
+import {getEnv, fetchEnvData} from './utils/envConfig';
 
 //make sure REACT environmental variables have been populated;
 fetchEnvData();
 
 // retrieve launch context from backend, if configured
-let context_url = process.env.PUBLIC_URL + '/launch-context.json';
-if (process.env.REACT_APP_CONF_API_URL){
-  context_url = process.env.REACT_APP_CONF_API_URL+'/auth/auth-info';
+let context_url = getEnv("PUBLIC_URL") + '/launch-context.json';
+if (getEnv("REACT_APP_CONF_API_URL")){
+  context_url = getEnv("REACT_APP_CONF_API_URL") +'/auth/auth-info';
 }
 
 fetch(context_url, {

--- a/src/styles/components/_Summary.scss
+++ b/src/styles/components/_Summary.scss
@@ -310,7 +310,7 @@
         }
         .panel.overview {
           max-width: 37.5%;
-          min-width: 250px;
+          min-width: 272px;
         }
         .sub-section__infopanel {
           border: 2px solid;

--- a/src/styles/components/_Summary.scss
+++ b/src/styles/components/_Summary.scss
@@ -310,7 +310,7 @@
         }
         .panel.overview {
           max-width: 37.5%;
-          min-width: 272px;
+          min-width: 32.5%;
         }
         .sub-section__infopanel {
           border: 2px solid;

--- a/src/utils/envConfig.js
+++ b/src/utils/envConfig.js
@@ -1,20 +1,6 @@
 export function fetchEnvData() {
-    //const envDefined = (typeof process !== "undefined") && process.env;
-    // if (envDefined) {
-    //     console.log("ENVIRONMENT DEFINED??? ", process.env);
-    //     let envKeys = Object.keys(process.env);
-    //     let arrLoaded = envKeys.filter(item => {
-    //         return item.startsWith("REACT_");
-    //     });
-    //     console.log("filtered env array? ", arrLoaded);
-    //     if (arrLoaded.length) {
-    //         //REACT environmental variables have been loaded, note, this is true in dev environment
-    //         console.log("env vars loaded!")
-    //         //return;
-    //     }
-    // }
     if (window["appConfig"] && Object.keys(window["appConfig"]).length) {
-        console.log("window config Added? ")
+        console.log("Window config variables added. ");
         return;
     }
     const setConfig = function () {
@@ -26,16 +12,10 @@ export function fetchEnvData() {
             return;
         }
         var envObj = JSON.parse(xhr.responseText);
-        // if (!envDefined) {
-        //     window["process"] = {};
-        //     window["process"]["env"] = {};
-        // }
         window["appConfig"] = {};
         //assign window process env variables for access by app
         for (var key in envObj) {
-            console.log("GET KEY ? ", key, " value? ", envObj[key])
             if (!window["appConfig"][key]) {
-                console.log("ONLY GET HERE IF NOT DEFINED ", key)
                 window["appConfig"][key] = envObj[key];
             }
         }
@@ -62,7 +42,9 @@ export function fetchEnvData() {
 
 export function getEnv (key) {
     const envDefined = (typeof process !== "undefined") && process.env;
+    //enviroment variables as defined by Node 
     if (envDefined && process.env[key]) return process.env[key];
+    //window application global variables
     if (window["appConfig"] && window["appConfig"][key]) return window["appConfig"][key];
     return "";
 }

--- a/src/utils/envConfig.js
+++ b/src/utils/envConfig.js
@@ -1,12 +1,14 @@
 export function fetchEnvData() {
     const envDefined = (typeof process !== "undefined") && process.env;
     if (envDefined) {
+        console.log("ENVIRONMENT DEFINED??? ", process.env);
         let envKeys = Object.keys(process.env);
         let arrLoaded = envKeys.filter(item => {
             return item.startsWith("REACT_");
         });
         if (arrLoaded.length) {
             //REACT environmental variables have been loaded, note, this is true in dev environment
+            console.log("env vars loaded!")
             return;
         }
     }
@@ -27,6 +29,7 @@ export function fetchEnvData() {
         for (var key in envObj) {
             window["process"]["env"][key] = envObj[key];
         }
+        console.log("loaded from env json ", window["process"]["env"])
     };
     var xhr = new XMLHttpRequest();
     xhr.open("GET", "/env.json", false);

--- a/src/utils/envConfig.js
+++ b/src/utils/envConfig.js
@@ -1,17 +1,21 @@
 export function fetchEnvData() {
-    const envDefined = (typeof process !== "undefined") && process.env;
-    if (envDefined) {
-        console.log("ENVIRONMENT DEFINED??? ", process.env);
-        let envKeys = Object.keys(process.env);
-        let arrLoaded = envKeys.filter(item => {
-            return item.startsWith("REACT_");
-        });
-        console.log("filtered env array? ", arrLoaded);
-        if (arrLoaded.length) {
-            //REACT environmental variables have been loaded, note, this is true in dev environment
-            console.log("env vars loaded!")
-            //return;
-        }
+    //const envDefined = (typeof process !== "undefined") && process.env;
+    // if (envDefined) {
+    //     console.log("ENVIRONMENT DEFINED??? ", process.env);
+    //     let envKeys = Object.keys(process.env);
+    //     let arrLoaded = envKeys.filter(item => {
+    //         return item.startsWith("REACT_");
+    //     });
+    //     console.log("filtered env array? ", arrLoaded);
+    //     if (arrLoaded.length) {
+    //         //REACT environmental variables have been loaded, note, this is true in dev environment
+    //         console.log("env vars loaded!")
+    //         //return;
+    //     }
+    // }
+    if (window["appConfig"] && Object.keys(window["appConfig"]).length) {
+        console.log("window config Added? ")
+        return;
     }
     const setConfig = function () {
         if (!xhr.readyState === xhr.DONE) {
@@ -22,19 +26,20 @@ export function fetchEnvData() {
             return;
         }
         var envObj = JSON.parse(xhr.responseText);
-        if (!envDefined) {
-            window["process"] = {};
-            window["process"]["env"] = {};
-        }
+        // if (!envDefined) {
+        //     window["process"] = {};
+        //     window["process"]["env"] = {};
+        // }
+        window["appConfig"] = {};
         //assign window process env variables for access by app
         for (var key in envObj) {
             console.log("GET KEY ? ", key, " value? ", envObj[key])
-            if (!process["env"][key]) {
+            if (!window["appConfig"][key]) {
                 console.log("ONLY GET HERE IF NOT DEFINED ", key)
-                process["env"][key] = envObj[key];
+                window["appConfig"][key] = envObj[key];
             }
         }
-        console.log("loaded from env json ", process["env"])
+        console.log("loaded from env json ",  window["appConfig"])
     };
     var xhr = new XMLHttpRequest();
     xhr.open("GET", "/env.json", false);
@@ -53,4 +58,11 @@ export function fetchEnvData() {
         // XMLHttpRequest timed out.
         console.log("request to fetch env.json file timed out ", e);
     };
+}
+
+export function getEnv (key) {
+    const envDefined = (typeof process !== "undefined") && process.env;
+    if (envDefined && process.env[key]) return process.env[key];
+    if (window["appConfig"] && window["appConfig"][key]) return window["appConfig"][key];
+    return "";
 }

--- a/src/utils/envConfig.js
+++ b/src/utils/envConfig.js
@@ -6,6 +6,7 @@ export function fetchEnvData() {
         let arrLoaded = envKeys.filter(item => {
             return item.startsWith("REACT_");
         });
+        console.log("filtered env array? ", arrLoaded);
         if (arrLoaded.length) {
             //REACT environmental variables have been loaded, note, this is true in dev environment
             console.log("env vars loaded!")

--- a/src/utils/envConfig.js
+++ b/src/utils/envConfig.js
@@ -14,12 +14,12 @@ export function fetchEnvData() {
         var envObj = JSON.parse(xhr.responseText);
         window["appConfig"] = {};
         //assign window process env variables for access by app
+        //won't be overridden when Node initializing env variables
         for (var key in envObj) {
             if (!window["appConfig"][key]) {
                 window["appConfig"][key] = envObj[key];
             }
         }
-        console.log("loaded from env json ",  window["appConfig"])
     };
     var xhr = new XMLHttpRequest();
     xhr.open("GET", "/env.json", false);

--- a/src/utils/envConfig.js
+++ b/src/utils/envConfig.js
@@ -9,7 +9,7 @@ export function fetchEnvData() {
         if (arrLoaded.length) {
             //REACT environmental variables have been loaded, note, this is true in dev environment
             console.log("env vars loaded!")
-            return;
+            //return;
         }
     }
     const setConfig = function () {
@@ -21,15 +21,19 @@ export function fetchEnvData() {
             return;
         }
         var envObj = JSON.parse(xhr.responseText);
-        if (!window["process"]) {
+        if (!envDefined) {
             window["process"] = {};
             window["process"]["env"] = {};
         }
         //assign window process env variables for access by app
         for (var key in envObj) {
-            window["process"]["env"][key] = envObj[key];
+            console.log("GET KEY ? ", key, " value? ", envObj[key])
+            if (!process["env"][key]) {
+                console.log("ONLY GET HERE IF NOT DEFINED ", key)
+                process["env"][key] = envObj[key];
+            }
         }
-        console.log("loaded from env json ", window["process"]["env"])
+        console.log("loaded from env json ", process["env"])
     };
     var xhr = new XMLHttpRequest();
     xhr.open("GET", "/env.json", false);


### PR DESCRIPTION
Issues addressed in this PR:

- read env.JSON file into global window variables that can be accessed by application and won't be overridden when Node initializing and processing env variables.
- fix bug raised due to change in PDMP Medication json structure
- add patient id as query parameter to get PDMP medications
- update demo data to be loaded (data with updated JSON structure) when call to API failed (TODO, load demo data only in demo environment)
