### PR TITLE
Lazy load education video

### DIFF
--- a/src/components/Video.js
+++ b/src/components/Video.js
@@ -19,6 +19,7 @@ export default class Video extends Component {
     e.preventDefault();
     /*
      * dynamically assigned src to iframe
+     * this allows video to be loaded on demand
      * only assign when it hasn't been assigned
      */
     if (!(this.iframeRef.current).src) {

--- a/src/components/Video.js
+++ b/src/components/Video.js
@@ -25,10 +25,6 @@ export default class Video extends Component {
       setTimeout(function() {
         (this.iframeRef.current).src = this.props.src;
       }.bind(this), 5);
-
-      // this.setState({
-      //   videoLoaded: true
-      // });
     }
     this.setState(state => ({
       isToggleOn: !state.isToggleOn

--- a/src/components/Video.js
+++ b/src/components/Video.js
@@ -54,12 +54,13 @@ export default class Video extends Component {
       height: 0
     };
 
-    if (!toggleable) {
-      return (<IframeElement title={title} style={IframeStyle} ref={this.iframeRef} />);
-    }
     const VideoElement = React.forwardRef((props, ref) => (
       <IframeElement {...props} forwardRef={ref}/>
     ));
+
+    if (!toggleable) {
+      return (<VideoElement title={title} style={IframeStyle} ref={this.iframeRef} />);
+    }
 
     return (
       <div>
@@ -78,7 +79,7 @@ export default class Video extends Component {
           >
           <span>loading...</span>
           <VideoElement ref={this.iframeRef} title={title} style={IframeStyle}  frameBorder="0"
-          id="ifVideo" allowFullScreen></VideoElement>
+          allowFullScreen></VideoElement>
           </div>
         </div>
       </div>

--- a/src/components/Video.js
+++ b/src/components/Video.js
@@ -12,10 +12,24 @@ export default class Video extends Component {
     };
     // This binding is necessary to make `this` work in the callback
     this.handleClick = this.handleClick.bind(this);
+    this.iframeRef = React.createRef();
   }
 
   handleClick(e) {
     e.preventDefault();
+    /*
+     * dynamically assigned src to iframe
+     * only assign when it hasn't been assigned
+     */
+    if (!(this.iframeRef.current).src) {
+      setTimeout(function() {
+        (this.iframeRef.current).src = this.props.src;
+      }.bind(this), 5);
+
+      // this.setState({
+      //   videoLoaded: true
+      // });
+    }
     this.setState(state => ({
       isToggleOn: !state.isToggleOn
     }));
@@ -23,7 +37,7 @@ export default class Video extends Component {
 
   render() {
     const {
-      title, src, toggleable
+      title, toggleable
     } = this.props;
 
     /*
@@ -44,8 +58,12 @@ export default class Video extends Component {
     };
 
     if (!toggleable) {
-      return (<IframeElement src={src} title={title} style={IframeStyle} />);
+      return (<IframeElement title={title} style={IframeStyle} ref={this.iframeRef} />);
     }
+    const VideoElement = React.forwardRef((props, ref) => (
+      <IframeElement {...props} forwardRef={ref}/>
+    ));
+
     return (
       <div>
         {/* element for toggling the visibility of video */}
@@ -61,7 +79,9 @@ export default class Video extends Component {
             className='video'
             style={VideoContainerStyle}
           >
-            <IframeElement src={src} title={title} style={IframeStyle} />
+          <span>loading...</span>
+          <VideoElement ref={this.iframeRef} title={title} style={IframeStyle}  frameBorder="0"
+          id="ifVideo" allowFullScreen></VideoElement>
           </div>
         </div>
       </div>

--- a/src/elements/Iframe.js
+++ b/src/elements/Iframe.js
@@ -4,15 +4,13 @@ import React from 'react';
  * embedded iframe element
  */
 
-const Iframe = ({ src, title, className, style}) => {
+const Iframe = (props) => {
+    const {forwardRef, ...rest} = props;
     return (
         <iframe
-        className={className}
-        style={style}
-        title={title}
-        src={`${src}`}
-        frameBorder="0"
-        allowFullScreen
+        title={props.title ||"iframe element"} //required attribute for iframe or browser complains
+        {...rest}
+        ref={forwardRef}
         />
     );
 };


### PR DESCRIPTION
address https://www.pivotaltracker.com/story/show/173475110 
Fix include:
Loading patient education video only when needed - as when user clicks like to see the video