### PR TITLE
fix doseQuantity calculator in MME Calculator

### DIFF
--- a/src/cql/r4/Factors_to_Consider_in_Managing_Chronic_Pain_FHIRv400.cql
+++ b/src/cql/r4/Factors_to_Consider_in_Managing_Chronic_Pain_FHIRv400.cql
@@ -53,7 +53,7 @@ using FHIR version '4.0.0'
 include CDS_Connect_Commons_for_FHIRv400 version '1.0.1' called C3F
 // The FHIRHelpers library provides common functions for simplifying interaction w/ the FHIR R4 data model.
 include FHIRHelpers version '4.0.0' called FHIRHelpers
-// The MMECalculator library is used to compute the patient's MME/MED 
+// The MMECalculator library is used to compute the patient's MME/MED
 include MMECalculator version '3.0.0' called MMECalculator
 
 
@@ -96,10 +96,10 @@ valueset "Substance use disorder": '2.16.840.1.113883.3.464.1003.106.12.1004'
 // [See value set in VSAC](https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.464.1003.106.11.1010/expansion)
 valueset "Substance Abuse": '2.16.840.1.113883.3.464.1003.106.11.1010'
 
-// [See value set in VSAC](https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1008/expansion) 
+// [See value set in VSAC](https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1008/expansion)
 valueset "Opioid overdose and poisoning (ICD10CM)": '2.16.840.1.113762.1.4.1146.1008'
 
-// [See value set in VSAC](https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1063/expansion) 
+// [See value set in VSAC](https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1063/expansion)
 valueset "Opioid overdose and poisoning (SNOMED)": '2.16.840.1.113762.1.4.1146.1063'
 
 // [See value set in VSAC](https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1032.102/expansion)
@@ -293,8 +293,8 @@ define function Abatement(c FHIR.Condition):
 // Returns the predicted last date for the prescription, based on the supply duration and quantity
 define function GetMedicationRequestEndDate(medRequest MedicationRequest):
   (medRequest) O
-   let 
-    CalculatedDuration: 
+   let
+    CalculatedDuration:
       if O.dispenseRequest.expectedSupplyDuration is not null
       then  O.dispenseRequest.expectedSupplyDuration.value.value
       else 0,
@@ -550,7 +550,7 @@ define ReportRiskFactorsForOpioidRelatedHarms:
 define OpioidMedicationRequests:
   C3F.MedicationRequestLookBack(
     [MedicationRequest: "Opioid Pain Medications"], //remove consideration for the status field
-    100 years 
+    100 years
   )
 
 define OpioidMedicationStatements:
@@ -598,12 +598,12 @@ define ReportOpioidMedications:
 // medication requests from PDMP
 // using relevant system identifier for filtering
 define PDMPMedicationRequests:
-  [MedicationRequest] M 
+  [MedicationRequest] M
   where M.identifier is not null and M.identifier[0].system ~ PDMP_SYSTEM_VALUE
 
 define ReportPDMPMedicationRequests:
   (PDMPMedicationRequests) O
-  let 
+  let
     CalculatedEnd: GetMedicationRequestEndDate(O)
     return {
       Type:  'Request',
@@ -623,7 +623,7 @@ define ReportPDMPMedicationRequests:
 define NonOpioidMedicationRequests:
   C3F.MedicationRequestLookBack(
     [MedicationRequest: "Non opiod pain medications"], //remove consideration for the status field
-    100 years 
+    100 years
   )
 
 define NonOpioidMedicationStatements:
@@ -766,12 +766,12 @@ define ReportCurrentMME:
     }
 }
 
-define ReportMME: 
+define ReportMME:
   [MedicationRequest: "Opioid Pain Medications"] O
-  let 
+  let
     MME_Object: MMECalculator.MME(O),
     CalculatedEnd: GetMedicationRequestEndDate(O),
-    CalculatedStatus: 
+    CalculatedStatus:
       if CalculatedEnd same or after Today() then 'active' else null
   return {
     Type:  'Request',
@@ -779,13 +779,15 @@ define ReportMME:
     CalculatedEnd: CalculatedEnd,
     End: ToString(CalculatedEnd),
     Status: CalculatedStatus,
+    doseQuantity: MME_Object[0].doseQuantity,
+    dosesPerDay: MME_Object[0].dosesPerDay,
     MMEValue: MME_Object[0].mme.value
   }
   sort by End desc
 
-define MMEDateList: 
+define MMEDateList:
   (ReportMME) R
-  where 
+  where
     R.End is not null and R.MMEValue is not null and (year from Today() - year from R.CalculatedEnd <= 2)
   return {
     End: R.End
@@ -799,7 +801,7 @@ define ReportMMEByDates:
   }
   sort by End
 
-define ReportPrescriptions: 
+define ReportPrescriptions:
   (OpioidMedicationRequests) M
   return MMECalculator.Prescriptions(M)
 
@@ -827,13 +829,13 @@ define ReportUrineDrugScreens:
 define BenzodiazepineMedicationRequests:
   C3F.MedicationRequestLookBack(
     [MedicationRequest: "Benzodiazepine medications"], //remove consideration for status field
-    100 years 
+    100 years
   )
 
 define BenzodiazepineMedicationStatements:
   C3F.MedicationStatementLookBack(
     [MedicationStatement: "Benzodiazepine medications"], //remove consideration for status field
-    100 years 
+    100 years
   )
 
 define ReportBenzodiazepineMedicationRequests:

--- a/src/cql/r4/Factors_to_Consider_in_Managing_Chronic_Pain_FHIRv400.json
+++ b/src/cql/r4/Factors_to_Consider_in_Managing_Chronic_Pain_FHIRv400.json
@@ -5391,6 +5391,40 @@
                            "type" : "QueryLetRef"
                         }
                      }, {
+                        "name" : "doseQuantity",
+                        "value" : {
+                           "path" : "doseQuantity",
+                           "type" : "Property",
+                           "source" : {
+                              "type" : "Indexer",
+                              "operand" : [ {
+                                 "name" : "MME_Object",
+                                 "type" : "QueryLetRef"
+                              }, {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "0",
+                                 "type" : "Literal"
+                              } ]
+                           }
+                        }
+                     }, {
+                        "name" : "dosesPerDay",
+                        "value" : {
+                           "path" : "dosesPerDay",
+                           "type" : "Property",
+                           "source" : {
+                              "type" : "Indexer",
+                              "operand" : [ {
+                                 "name" : "MME_Object",
+                                 "type" : "QueryLetRef"
+                              }, {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "0",
+                                 "type" : "Literal"
+                              } ]
+                           }
+                        }
+                     }, {
                         "name" : "MMEValue",
                         "value" : {
                            "path" : "value",

--- a/src/cql/r4/MMECalculator.cql
+++ b/src/cql/r4/MMECalculator.cql
@@ -66,7 +66,14 @@ define function GetMedicationQuantity(medication MedicationRequest):
       ingredient: OMTKLogic.GetIngredients(rxNormCode),
       prescription: if ingredient is not null then First(ingredient) else null,
       dosageInstruction: O.dosageInstruction[0],
-      dispenseRequestQuantity: O.dispenseRequest.quantity.value.value,
+      dispenseRequest: O.dispenseRequest,
+      supplyDuration: if dispenseRequest.expectedSupplyDuration is not null then System.Quantity {
+        value: dispenseRequest.expectedSupplyDuration.value,
+        unit: dispenseRequest.expectedSupplyDuration.unit
+      } else null as System.Quantity,
+      dispenseRequestQuantity: dispenseRequest.quantity.value.value,
+      //get dose quantity daily
+      dispenseRequestDoseQuantity: if supplyDuration is not null then dispenseRequestQuantity / supplyDuration.value else null as System.Quantity,
       doseAndRate:  if dosageInstruction is not null then dosageInstruction.doseAndRate[0] else null, //either a single doseRange or doseQuantity see specs here:  https://www.hl7.org/fhir/dosage-definitions.html#Dosage.doseAndRate.dose_x_
       dosage: if doseAndRate is not null then doseAndRate.dose else null,
       doseRange: if dosage is not null then ToFHIRRange(dosage) else null as Range,
@@ -75,15 +82,15 @@ define function GetMedicationQuantity(medication MedicationRequest):
                 then OMTKLogic.ToUCUM(prescription.strength.unit) else null,
       doseQuantity:
               case
-                when dispenseRequestQuantity is not null then dispenseRequestQuantity
                 when dosage is not null and dosage.high is null then
                   System.Quantity {
                       value: dosage.value.value,
                       unit: doseUnit
                   }
+                when dispenseRequestDoseQuantity is not null then dispenseRequestDoseQuantity
                 else null as System.Quantity
               end
-      return  case 
+      return  case
                 when doseRange is not null and doseRange.high is not null then ToQuantity(doseRange.high)
                 when doseQuantity is not null then doseQuantity
                 else null as System.Quantity
@@ -106,8 +113,8 @@ define function Prescriptions(Orders List<MedicationRequest>):
       repeat: dosageInstruction.timing.repeat,
       frequency: Coalesce(repeat.frequencyMax.value, repeat.frequency.value),
       dispenseRequest: O.dispenseRequest,
-      supplyDuration: if repeat.period is not null then 
-        repeat.period.value else 
+      supplyDuration: if repeat.period is not null then
+        repeat.period.value else
         dispenseRequest.expectedSupplyDuration.value.value,
       period: OMTKLogic.Quantity(supplyDuration, repeat.periodUnit.value),
       doseRange: ToFHIRRange(doseAndRate.dose),
@@ -159,6 +166,8 @@ define function MME(prescriptions List<MedicationRequest>):
       isDraft: P.isDraft,
       isPRN: P.isPRN,
       prescription: P.prescription,
+      doseQuantity: P.dose,
+      dosesPerDay: P.dosesPerDay,
       dailyDose: Combine(mmePerIngredient X return X.dailyDoseDescription, '\r\n'),
       mme: Sum(mmePerIngredient X return X.mme)
     }

--- a/src/cql/r4/MMECalculator.json
+++ b/src/cql/r4/MMECalculator.json
@@ -413,6 +413,90 @@
                      } ]
                   }
                }, {
+                  "identifier" : "dispenseRequest",
+                  "expression" : {
+                     "path" : "dispenseRequest",
+                     "scope" : "O",
+                     "type" : "Property"
+                  }
+               }, {
+                  "identifier" : "supplyDuration",
+                  "expression" : {
+                     "type" : "If",
+                     "condition" : {
+                        "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                        "type" : "As",
+                        "operand" : {
+                           "type" : "Not",
+                           "operand" : {
+                              "type" : "IsNull",
+                              "operand" : {
+                                 "path" : "expectedSupplyDuration",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "dispenseRequest",
+                                    "type" : "QueryLetRef"
+                                 }
+                              }
+                           }
+                        }
+                     },
+                     "then" : {
+                        "classType" : "{urn:hl7-org:elm-types:r1}Quantity",
+                        "type" : "Instance",
+                        "element" : [ {
+                           "name" : "value",
+                           "value" : {
+                              "name" : "ToDecimal",
+                              "libraryName" : "FHIRHelpers",
+                              "type" : "FunctionRef",
+                              "operand" : [ {
+                                 "path" : "value",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "path" : "expectedSupplyDuration",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "dispenseRequest",
+                                       "type" : "QueryLetRef"
+                                    }
+                                 }
+                              } ]
+                           }
+                        }, {
+                           "name" : "unit",
+                           "value" : {
+                              "name" : "ToString",
+                              "libraryName" : "FHIRHelpers",
+                              "type" : "FunctionRef",
+                              "operand" : [ {
+                                 "path" : "unit",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "path" : "expectedSupplyDuration",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "dispenseRequest",
+                                       "type" : "QueryLetRef"
+                                    }
+                                 }
+                              } ]
+                           }
+                        } ]
+                     },
+                     "else" : {
+                        "strict" : false,
+                        "type" : "As",
+                        "operand" : {
+                           "type" : "Null"
+                        },
+                        "asTypeSpecifier" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }
+                  }
+               }, {
                   "identifier" : "dispenseRequestQuantity",
                   "expression" : {
                      "path" : "value",
@@ -424,10 +508,56 @@
                            "path" : "quantity",
                            "type" : "Property",
                            "source" : {
-                              "path" : "dispenseRequest",
-                              "scope" : "O",
-                              "type" : "Property"
+                              "name" : "dispenseRequest",
+                              "type" : "QueryLetRef"
                            }
+                        }
+                     }
+                  }
+               }, {
+                  "identifier" : "dispenseRequestDoseQuantity",
+                  "expression" : {
+                     "type" : "If",
+                     "condition" : {
+                        "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                        "type" : "As",
+                        "operand" : {
+                           "type" : "Not",
+                           "operand" : {
+                              "type" : "IsNull",
+                              "operand" : {
+                                 "name" : "supplyDuration",
+                                 "type" : "QueryLetRef"
+                              }
+                           }
+                        }
+                     },
+                     "then" : {
+                        "type" : "ToQuantity",
+                        "operand" : {
+                           "type" : "Divide",
+                           "operand" : [ {
+                              "name" : "dispenseRequestQuantity",
+                              "type" : "QueryLetRef"
+                           }, {
+                              "path" : "value",
+                              "type" : "Property",
+                              "source" : {
+                                 "name" : "supplyDuration",
+                                 "type" : "QueryLetRef"
+                              }
+                           } ]
+                        }
+                     },
+                     "else" : {
+                        "strict" : false,
+                        "type" : "As",
+                        "operand" : {
+                           "type" : "Null"
+                        },
+                        "asTypeSpecifier" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                           "type" : "NamedTypeSpecifier"
                         }
                      }
                   }
@@ -642,24 +772,6 @@
                      "type" : "Case",
                      "caseItem" : [ {
                         "when" : {
-                           "type" : "Not",
-                           "operand" : {
-                              "type" : "IsNull",
-                              "operand" : {
-                                 "name" : "dispenseRequestQuantity",
-                                 "type" : "QueryLetRef"
-                              }
-                           }
-                        },
-                        "then" : {
-                           "type" : "ToQuantity",
-                           "operand" : {
-                              "name" : "dispenseRequestQuantity",
-                              "type" : "QueryLetRef"
-                           }
-                        }
-                     }, {
-                        "when" : {
                            "type" : "And",
                            "operand" : [ {
                               "type" : "Not",
@@ -706,6 +818,21 @@
                                  "type" : "QueryLetRef"
                               }
                            } ]
+                        }
+                     }, {
+                        "when" : {
+                           "type" : "Not",
+                           "operand" : {
+                              "type" : "IsNull",
+                              "operand" : {
+                                 "name" : "dispenseRequestDoseQuantity",
+                                 "type" : "QueryLetRef"
+                              }
+                           }
+                        },
+                        "then" : {
+                           "name" : "dispenseRequestDoseQuantity",
+                           "type" : "QueryLetRef"
                         }
                      } ],
                      "else" : {
@@ -1539,6 +1666,20 @@
                         "name" : "prescription",
                         "value" : {
                            "path" : "prescription",
+                           "scope" : "P",
+                           "type" : "Property"
+                        }
+                     }, {
+                        "name" : "doseQuantity",
+                        "value" : {
+                           "path" : "dose",
+                           "scope" : "P",
+                           "type" : "Property"
+                        }
+                     }, {
+                        "name" : "dosesPerDay",
+                        "value" : {
+                           "path" : "dosesPerDay",
                            "scope" : "P",
                            "type" : "Property"
                         }

--- a/src/utils/r4_test_patients/brenda_jackson.json
+++ b/src/utils/r4_test_patients/brenda_jackson.json
@@ -723,7 +723,7 @@
             "timing": {
               "repeat": {
                 "frequency": 1,
-                "period": 3.0,
+                "period": 30.0,
                 "periodUnit": "d"
               }
             },
@@ -753,7 +753,7 @@
             "start": "2020-09-05",
             "end": "2020-12-25"
           },
-          "numberOfRepeatsAllowed": 3,
+          "numberOfRepeatsAllowed": 1,
           "expectedSupplyDuration": {
             "value": 30,
             "unit": "days",
@@ -1340,48 +1340,146 @@
     },
     {
       "resource": {
-        "resourceType": "MedicationRequest",
+        "authoredOn": "2019-10-25",
         "id": "20f04037-b4ed-46ac-9222-c11f1e54580f",
         "subject": {
           "reference": "Patient/5c41cecf-cf81-434f-9da7-e24e5a99dbc2"
         },
-        "status": "active",
-        "intent": "order",
-        "doNotPerform": false,
+        "dosageInstruction": [
+          {
+            "doseAndRate": [
+              {
+                "doseQuantity": {
+                  "value": 1.0
+                }
+              }
+            ],
+            "timing": {
+              "repeat": {
+                "frequency": 1.0,
+                "period": 1.0,
+                "periodUnit": "d"
+              }
+            }
+          }
+        ],
+        "dispenseRequest": {
+          "expectedSupplyDuration": {
+            "code": "d",
+            "system": "http://unitsofmeasure.org",
+            "unit": "days",
+            "value": 30.0
+          },
+          "extension": [
+            {
+              "url": "http://cosri.org/fhir/pharmacy_name",
+              "valueString": "TEST, DOCTOR"
+            },
+            {
+              "url": "http://cosri.org/fhir/last_fill",
+              "valueDate": "2019-10-25"
+            }
+          ],
+          "quantity": {
+            "value": 30.0
+          }
+        },
+        "identifier": [
+          {
+            "system": "https://github.com/uwcirg/script-fhir-facade/"
+          }
+        ],
         "medicationCodeableConcept": {
           "coding": [
             {
-              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-              "code": "1049717",
-              "display": "Oxycodone Hydrochloride 10 MG Oral Capsule"
+              "code": "49999084830",
+              "display": "morphine sulfate 15 MG Oral Tablet",
+              "system": "http://hl7.org/fhir/sid/ndc"
+            },
+            {
+              "code": "892582",
+              "display": "morphine sulfate 15 MG Oral Tablet",
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm"
             }
           ],
-          "text": "Oxycodone Hydrochloride 10 MG Oral Capsule"
+          "text": "morphine sulfate 15 MG Oral Tablet"
         },
-        "authoredOn": "2018-10-15T16:01:00.000Z"
+        "requester": {
+          "display": "TEST PRESCRIBER"
+        },
+        "resourceType": "MedicationRequest"
       }
     },
     {
       "resource": {
-        "resourceType": "MedicationRequest",
+        "authoredOn": "2020-10-25",
         "id": "3e14d51b-58d8-4e7a-b9e3-26893e5604d2",
         "subject": {
           "reference": "Patient/5c41cecf-cf81-434f-9da7-e24e5a99dbc2"
         },
-        "status": "active",
-        "intent": "order",
-        "doNotPerform": false,
+        "dosageInstruction": [
+          {
+            "doseAndRate": [
+              {
+                "doseQuantity": {
+                  "value": 2.0
+                }
+              }
+            ],
+            "timing": {
+              "repeat": {
+                "frequency": 15.0,
+                "period": 15.0,
+                "periodUnit": "d"
+              }
+            }
+          }
+        ],
+        "dispenseRequest": {
+          "expectedSupplyDuration": {
+            "code": "d",
+            "system": "http://unitsofmeasure.org",
+            "unit": "days",
+            "value": 15.0
+          },
+          "extension": [
+            {
+              "url": "http://cosri.org/fhir/pharmacy_name",
+              "valueString": "TEST, DOCTOR"
+            },
+            {
+              "url": "http://cosri.org/fhir/last_fill",
+              "valueDate": "2020-10-25"
+            }
+          ],
+          "quantity": {
+            "value": 30.0
+          }
+        },
+        "identifier": [
+          {
+            "system": "https://github.com/uwcirg/script-fhir-facade/"
+          }
+        ],
         "medicationCodeableConcept": {
           "coding": [
             {
-              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-              "code": "1049717",
-              "display": "Oxycodone Hydrochloride 10 MG Oral Capsule"
+              "code": "49999084830",
+              "display": "morphine sulfate 15 MG Oral Tablet",
+              "system": "http://hl7.org/fhir/sid/ndc"
+            },
+            {
+              "code": "892582",
+              "display": "morphine sulfate 15 MG Oral Tablet",
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm"
             }
           ],
-          "text": "Oxycodone Hydrochloride 10 MG Oral Capsule"
+          "text": "morphine sulfate 15 MG Oral Tablet"
         },
-        "authoredOn": "2018-07-15T16:01:00.000Z"
+        "requester": {
+          "display": "TEST PRESCRIBER"
+        },
+        "resourceType": "MedicationRequest"
       }
     },
     {


### PR DESCRIPTION
Fix doseQuantity calculation in MME Calculator CQL

Changes include:

1.  update code to look for `dosageInstruction . doseAndRate . doseQuantity ` for doseQuantity in a MedicationRequest
2.  if 1. is not present, calculate doseQuantity by  `dispense quantity / expected supply duration`
3. add example MedicationRequests to Brenda Jackson  patient JSON for testing

[Preview](https://launch.smarthealthit.org/launcher?launch_uri=https%3A%2F%2Fdeploy-preview-70--distracted-jepsen-bc9c39.netlify.com%2Flaunch.html&patient=5c41cecf-cf81-434f-9da7-e24e5a99dbc2&fhir_ver=4)

