### PR TITLE
Bugfix/mme graph rendering fix

### DIFF
--- a/default.env
+++ b/default.env
@@ -11,3 +11,7 @@ REACT_APP_CONF_API_URL=http://localtest.me:5000
 #FRONTEND_DOCKERFILE=Dockerfile.production
 # Override when using apache to serve in production
 #T_PORT=80
+
+# variable that drives whether to render MME graph using mock data
+# set to true if so
+USE_DEMO=false

--- a/src/components/DevTools.js
+++ b/src/components/DevTools.js
@@ -10,7 +10,8 @@ export default class DevTools extends Component {
       displayDevTools: false,
       displayFhirQueries: false,
       displayCQLResults: false,
-      displayPDMPResults: false
+      displayPDMPResults: false,
+      displayOtherResults: false
     };
   }
 
@@ -32,6 +33,11 @@ export default class DevTools extends Component {
   togglePDMPResults = (event) => {
     event.preventDefault();
     this.setState({ displayPDMPResults: !this.state.displayPDMPResults});
+  }
+
+  toggleOtherResults = (event) => {
+    event.preventDefault();
+    this.setState({ displayOtherResults: !this.state.displayOtherResults});
   }
 
   errorMessage(er, i) {
@@ -92,7 +98,7 @@ export default class DevTools extends Component {
         <h4>CQL Results <button onClick={this.toggleCQLResults}>[show/hide]</button></h4>
 
         <div style={{ display: this.state.displayCQLResults ? 'block' : 'none' }}>
-          <pre>{JSON.stringify(this.props.result, null, 2)}</pre>
+          <pre>{JSON.stringify(this.props.summary, null, 2)}</pre>
         </div>
       </div>
     );
@@ -104,9 +110,21 @@ export default class DevTools extends Component {
       <div className='pdmp-results'>
         <h4>PDMP Results <button onClick={this.togglePDMPResults}>[show/hide]</button></h4>
         <div style={{ display: this.state.displayPDMPResults ? 'block' : 'none' }}>
-          <pre>{pdmpDataset ? 
-                JSON.stringify(pdmpDataset, null, 2) : 
+          <pre>{pdmpDataset ?
+                JSON.stringify(pdmpDataset, null, 2) :
                 'No result'}</pre>
+        </div>
+      </div>
+    );
+  }
+
+  renderOtherResults() {
+    return (
+      <div className="other-results">
+        <h4>Other Results <button onClick={this.toggleOtherResults}>[show/hide]</button></h4>
+
+        <div style={{ display: this.state.displayOtherResults ? 'block' : 'none' }}>
+          <pre>{JSON.stringify(this.props.other, null, 2)}</pre>
         </div>
       </div>
     );
@@ -128,6 +146,7 @@ export default class DevTools extends Component {
           {this.renderFHIRQueries()}
           {this.renderCQLResults()}
           {this.renderPDMPResults()}
+          {this.renderOtherResults()}
         </div>
       </div>
     );
@@ -136,6 +155,6 @@ export default class DevTools extends Component {
 
 DevTools.propTypes = {
   collector: PropTypes.array.isRequired,
-  result: PropTypes.object.isRequired,
-  summary: PropTypes.object.isRequired
+  summary: PropTypes.object.isRequired,
+  other: PropTypes.object,
 };

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -375,16 +375,17 @@ export default class Landing extends Component {
               finalDataPoints.push(dataPoint);
             } else {
               
-              if (nextObj && nextObj[MMEValueFieldName] !== currentDataPoint[MMEValueFieldName]) {
-                  currentDataPoint[PLACEHOLDER_FIELD_NAME] = false;
-                  finalDataPoints.push(currentDataPoint); 
+              if (prevObj && prevObj[MMEValueFieldName] !== currentDataPoint[MMEValueFieldName]) {
+                  
                   //add data point with older value for the previous med
-                  nextObj[PLACEHOLDER_FIELD_NAME] = false;
+                  prevObj[PLACEHOLDER_FIELD_NAME] = false;
                   dataPoint = {};
-                  dataPoint[graphDateFieldName] = nextObj[graphDateFieldName];
-                  dataPoint[MMEValueFieldName] = currentDataPoint[MMEValueFieldName];
+                  dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
+                  dataPoint[MMEValueFieldName] = prevObj[MMEValueFieldName];
                   dataPoint[PLACEHOLDER_FIELD_NAME] = true;
                   finalDataPoints.push(dataPoint);
+                  currentDataPoint[PLACEHOLDER_FIELD_NAME] = false;
+                  finalDataPoints.push(currentDataPoint); 
                   
                }
               

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -301,7 +301,7 @@ export default class Landing extends Component {
             dataPoint[MMEValueFieldName] = currentMedicationItem[MMEValueFieldName];
             dataPoint[PLACEHOLDER_FIELD_NAME] = true;
             dataPoint[startDateFieldName] = dataDate;
-            dataPoint = {...currentMedicationItem, ...dataPoint};
+            dataPoint = {...dataPoint, ...currentMedicationItem};
             dataPoints.push(dataPoint);
           }
         }
@@ -313,7 +313,7 @@ export default class Landing extends Component {
         dataPoint[END_DELIMITER_FIELD_NAME] = true;
         //add delimiter flag to denote the end of the medication, if not overlapping with next med
         // if (!nextObj || (nextObj && (dateNumberFormat(currentMedicationItem[endDateFieldName]) < dateNumberFormat(nextObj[startDateFieldName])) && (dateNumberFormat(currentMedicationItem[endDateFieldName]) < dateNumberFormat(nextObj[endDateFieldName])))) dataPoint[END_DELIMITER_FIELD_NAME] = true;
-        dataPoint = {...currentMedicationItem, ...dataPoint};
+        dataPoint = {...dataPoint, ...currentMedicationItem};
         dataPoints.push(dataPoint);
         prevObj = currentMedicationItem;
 
@@ -366,7 +366,7 @@ export default class Landing extends Component {
         //overlapping data points
         if (prevObj && (prevObj[MMEValueFieldName] !== currentDataPoint[MMEValueFieldName])) {
           //add data point with older value for the previous med
-          prevObj[PLACEHOLDER_FIELD_NAME] = false;
+          prevObj[PLACEHOLDER_FIELD_NAME] = !prevObj["dummy"] ? false : true;
           dataPoint = {};
           dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
           dataPoint[MMEValueFieldName] = prevObj[MMEValueFieldName];
@@ -379,6 +379,7 @@ export default class Landing extends Component {
             dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
             dataPoint[MMEValueFieldName] = 0;
             dataPoint[START_DELIMITER_FIELD_NAME] = true;
+            dataPoint["dummy"] = true;
             dataPoint[PLACEHOLDER_FIELD_NAME] = true;
             finalDataPoints.push(dataPoint);
             //add current data point
@@ -390,6 +391,7 @@ export default class Landing extends Component {
             dataPoint = {};
             dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
             dataPoint[MMEValueFieldName] = 0;
+            dataPoint["dummy"] = true;
             dataPoint[END_DELIMITER_FIELD_NAME] = true;
             dataPoint[PLACEHOLDER_FIELD_NAME] = true;
             finalDataPoints.push(dataPoint);
@@ -407,7 +409,7 @@ export default class Landing extends Component {
           dataPoint[PLACEHOLDER_FIELD_NAME] = true;
           finalDataPoints.push(dataPoint);
         }
-        prevObj = currentDataPoint;
+        prevObj = finalDataPoints[finalDataPoints.length-1];
       });
       console.log("graph data ", finalDataPoints);
       summary[overviewSectionKey+"_graph"] = finalDataPoints;

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -256,18 +256,15 @@ export default class Landing extends Component {
         }
       });
       const [startDateFieldName, endDateFieldName, MMEValueFieldName, graphDateFieldName] = [graphConfig.startDateField, graphConfig.endDateField, graphConfig.mmeField, graphConfig.graphDateField];
-      // const endDateFieldName = graphConfig.endDateField;
-      // const MMEValueFieldName = graphConfig.mmeField;
-      // const graphDateFieldName = graphConfig.graphDateField;
       const DELIMITER_FIELD_NAME = "delimiter";
       const PLACEHOLDER_FIELD_NAME = "placeholder";
 
+      //sort data by start date
       graph_data = graph_data.filter(function(item) {
         return item[startDateFieldName] && item[endDateFieldName];
       }).sort(function(a, b) {
         return dateCompare(a[startDateFieldName], b[startDateFieldName]);
       });
-      console.log("sorted original graph data ", graph_data)
 
       let dataPoints = [];
       let prevObj = null, nextObj = null;
@@ -276,11 +273,10 @@ export default class Landing extends Component {
           let startDate = extractDateFromGMTDateString(item[startDateFieldName]);
           let endDate = extractDateFromGMTDateString(item[endDateFieldName]);
           let [oStartDate, oEndDate] = [new Date(startDate), new Date(endDate)];
-          //let oEndDate = new Date(endDate);
           let diffTime = oEndDate - oStartDate;
           let diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
           nextObj =  (index+1) <= graph_data.length-1 ? graph_data[index+1]: null;
-          //console.log("start date ", startDate, " end Date ", endDate, " dff days " , diffDays)
+
           //add (0, 0) data point to denote start of a new med, only if the start date does not overlap with the end date of the previous med
           if (!prevObj || (prevObj && (dateNumberFormat(item[startDateFieldName]) >= dateNumberFormat(prevObj[endDateFieldName])))){
             dataPoint = {};
@@ -350,8 +346,7 @@ export default class Landing extends Component {
         if (matchedItems.length <= 1) return true;
         matchedItems.forEach(o => {
           cumMMEValue += o[MMEValueFieldName];
-        })
-        //console.log("matchedItems ", matchedItems, " cum ", cumMMEValue);
+        });
         dataPoints.forEach((item) => {
           if (item.date === pointDate && !item[DELIMITER_FIELD_NAME]) { //don't change MME value for (0,0) delimiting data point
             item[MMEValueFieldName] = cumMMEValue;

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -359,7 +359,7 @@ export default class Landing extends Component {
               dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
               dataPoint[MMEValueFieldName] = 0;
               dataPoint[START_DELIMITER_FIELD_NAME] = true;
-              dataPoint[PLACEHOLDER_FIELD_NAME] = true;
+              if (!prevObj) dataPoint[PLACEHOLDER_FIELD_NAME] = true;
               finalDataPoints.push(dataPoint);
               //add current data point
               finalDataPoints.push(currentDataPoint); 
@@ -371,7 +371,7 @@ export default class Landing extends Component {
               dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
               dataPoint[MMEValueFieldName] = 0;
               dataPoint[END_DELIMITER_FIELD_NAME] = true;
-              dataPoint[PLACEHOLDER_FIELD_NAME] = true;
+              if (!nextObj) dataPoint[PLACEHOLDER_FIELD_NAME] = true;
               finalDataPoints.push(dataPoint);
             } else {
               

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -376,7 +376,7 @@ export default class Landing extends Component {
 
             //add end delimiting (0, 0) data point
             if (currentDataPoint[END_DELIMITER_FIELD_NAME]) {
-              finalDataPoints.push(currentDataPoint);
+              //finalDataPoints.push(currentDataPoint);
               dataPoint = {};
               dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
               dataPoint[MMEValueFieldName] = 0;

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -345,13 +345,13 @@ export default class Landing extends Component {
       dataPoints.forEach(function(currentDataPoint, index) {
         let dataPoint = {};
         nextObj = dataPoints[index+1] ? dataPoints[index+1]: null;
-        if (index === 0) {
-          dataPoint = {};
-          dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
-          dataPoint[MMEValueFieldName] = 0;
-          dataPoint[PLACEHOLDER_FIELD_NAME] = true;
-          finalDataPoints.push(dataPoint);
-        }
+     //   if (index === 0) {
+     //     dataPoint = {};
+     //     dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
+     //     dataPoint[MMEValueFieldName] = 0;
+     //     dataPoint[PLACEHOLDER_FIELD_NAME] = true;
+     //     finalDataPoints.push(dataPoint);
+      //  }
          
             //add start delimiting (0, 0) data point
             if (currentDataPoint[START_DELIMITER_FIELD_NAME]) {
@@ -375,16 +375,17 @@ export default class Landing extends Component {
               finalDataPoints.push(dataPoint);
             } else {
               
-              if (prevObj && prevObj[MMEValueFieldName] !== currentDataPoint[MMEValueFieldName]) {
+              if (nextObj && nextObj[MMEValueFieldName] !== currentDataPoint[MMEValueFieldName]) {
+                  currentDataPoint[PLACEHOLDER_FIELD_NAME] = false;
+                  finalDataPoints.push(currentDataPoint); 
                   //add data point with older value for the previous med
-                  prevObj[PLACEHOLDER_FIELD_NAME] = false;
+                  nextObj[PLACEHOLDER_FIELD_NAME] = false;
                   dataPoint = {};
-                  dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
-                  dataPoint[MMEValueFieldName] = prevObj[MMEValueFieldName];
+                  dataPoint[graphDateFieldName] = nextObj[graphDateFieldName];
+                  dataPoint[MMEValueFieldName] = currentDataPoint[MMEValueFieldName];
                   dataPoint[PLACEHOLDER_FIELD_NAME] = true;
                   finalDataPoints.push(dataPoint);
-                  currentDataPoint[PLACEHOLDER_FIELD_NAME] = false;
-                  finalDataPoints.push(currentDataPoint);
+                  
                }
               
             }
@@ -392,13 +393,13 @@ export default class Landing extends Component {
                          
                          
         //add end of line point denoting end of med
-        if (!nextObj) {
-          dataPoint = {};
-          dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
-          dataPoint[MMEValueFieldName] = 0;
-          dataPoint[PLACEHOLDER_FIELD_NAME] = true;
-          finalDataPoints.push(dataPoint);
-        }
+      //  if (!nextObj) {
+      //    dataPoint = {};
+      //    dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
+      //    dataPoint[MMEValueFieldName] = 0;
+       //   dataPoint[PLACEHOLDER_FIELD_NAME] = true;
+      //    finalDataPoints.push(dataPoint);
+      //  }
         prevObj = currentDataPoint;
       });
       console.log("graph data ", finalDataPoints);

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -382,7 +382,7 @@ export default class Landing extends Component {
                   dataPoint = {};
                   dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
                   dataPoint[MMEValueFieldName] = prevObj[MMEValueFieldName];
-                  dataPoint[PLACEHOLDER_FIELD_NAME] = true;
+                 // dataPoint[PLACEHOLDER_FIELD_NAME] = true;
                   finalDataPoints.push(dataPoint);
                   currentDataPoint[PLACEHOLDER_FIELD_NAME] = false;
                   finalDataPoints.push(currentDataPoint); 

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -282,6 +282,7 @@ export default class Landing extends Component {
         dataPoint = {};
         dataPoint[graphDateFieldName] = currentMedicationItem[startDateFieldName];
         dataPoint[MMEValueFieldName] = currentMedicationItem[MMEValueFieldName];
+        dataPoint[START_DELIMITER_FIELD_NAME] = true;
         dataPoint = {...dataPoint, ...currentMedicationItem};
         dataPoints.push(dataPoint);
 
@@ -308,6 +309,7 @@ export default class Landing extends Component {
         dataPoint = {};
         dataPoint[graphDateFieldName] = currentMedicationItem[endDateFieldName];
         dataPoint[MMEValueFieldName] = currentMedicationItem[MMEValueFieldName];
+        dataPoint[END_DELIMITER_FIELD_NAME] = true;
         //add delimiter flag to denote the end of the medication, if not overlapping with next med
         // if (!nextObj || (nextObj && (dateNumberFormat(currentMedicationItem[endDateFieldName]) < dateNumberFormat(nextObj[startDateFieldName])) && (dateNumberFormat(currentMedicationItem[endDateFieldName]) < dateNumberFormat(nextObj[endDateFieldName])))) dataPoint[END_DELIMITER_FIELD_NAME] = true;
         dataPoint = {...dataPoint, ...currentMedicationItem};
@@ -371,7 +373,7 @@ export default class Landing extends Component {
           finalDataPoints.push(dataPoint);
           currentDataPoint[PLACEHOLDER_FIELD_NAME] = false;
           finalDataPoints.push(currentDataPoint);
-        } else if (prevObj && dateNumberFormat(currentDataPoint[startDateFieldName]) > dateNumberFormat(prevObj[endDateFieldName])) {
+        } else if (prevObj && currentDataPoint[START_DELIMITER_FIELD_NAME] && dateNumberFormat(currentDataPoint[startDateFieldName]) > dateNumberFormat(prevObj[endDateFieldName])) {
             dataPoint = {};
             dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
             dataPoint[MMEValueFieldName] = 0;
@@ -381,7 +383,7 @@ export default class Landing extends Component {
             //add current data point
             finalDataPoints.push(currentDataPoint);
         }
-        else if (nextObj && (dateNumberFormat(currentDataPoint[endDateFieldName]) < dateNumberFormat(nextObj[startDateFieldName])) && (dateNumberFormat(currentDataPoint[endDateFieldName]) < dateNumberFormat(nextObj[endDateFieldName]))) {
+        else if (nextObj && currentDataPoint[END_DELIMITER_FIELD_NAME] && (dateNumberFormat(currentDataPoint[endDateFieldName]) < dateNumberFormat(nextObj[startDateFieldName])) && (dateNumberFormat(currentDataPoint[endDateFieldName]) < dateNumberFormat(nextObj[endDateFieldName]))) {
             //add current data point
             finalDataPoints.push(currentDataPoint);
             dataPoint = {};

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -387,7 +387,7 @@ export default class Landing extends Component {
                   currentDataPoint[PLACEHOLDER_FIELD_NAME] = false;
                   finalDataPoints.push(currentDataPoint); 
                   
-               }
+               } else finalDataPoints.push(currentDataPoint); 
               
             }
   

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -300,7 +300,8 @@ export default class Landing extends Component {
             dataPoint[graphDateFieldName] = dataDate;
             dataPoint[MMEValueFieldName] = currentMedicationItem[MMEValueFieldName];
             dataPoint[PLACEHOLDER_FIELD_NAME] = true;
-            dataPoint = {...dataPoint, ...currentMedicationItem};
+            dataPoint[startDateFieldName] = dataDate;
+            dataPoint = {...currentMedicationItem, ...dataPoint};
             dataPoints.push(dataPoint);
           }
         }
@@ -312,7 +313,7 @@ export default class Landing extends Component {
         dataPoint[END_DELIMITER_FIELD_NAME] = true;
         //add delimiter flag to denote the end of the medication, if not overlapping with next med
         // if (!nextObj || (nextObj && (dateNumberFormat(currentMedicationItem[endDateFieldName]) < dateNumberFormat(nextObj[startDateFieldName])) && (dateNumberFormat(currentMedicationItem[endDateFieldName]) < dateNumberFormat(nextObj[endDateFieldName])))) dataPoint[END_DELIMITER_FIELD_NAME] = true;
-        dataPoint = {...dataPoint, ...currentMedicationItem};
+        dataPoint = {...currentMedicationItem, ...dataPoint};
         dataPoints.push(dataPoint);
         prevObj = currentMedicationItem;
 

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -368,6 +368,7 @@ export default class Landing extends Component {
               dataPoint = {};
               dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
               dataPoint[MMEValueFieldName] = 0;
+              dataPoint[START_DELIMITER_FIELD_NAME] = true;
               dataPoint[PLACEHOLDER_FIELD_NAME] = true;
               finalDataPoints.push(dataPoint);
             }
@@ -380,6 +381,7 @@ export default class Landing extends Component {
               dataPoint = {};
               dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
               dataPoint[MMEValueFieldName] = 0;
+              dataPoint[END_DELIMITER_FIELD_NAME] = true;
               dataPoint[PLACEHOLDER_FIELD_NAME] = true;
               finalDataPoints.push(dataPoint);
             }

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -5,7 +5,8 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import executeElm from '../utils/executeELM';
 import flagit from '../helpers/flagit';
-import {datishFormat} from '../helpers/formatit';
+import {datishFormat, dateFormat, dateNumberFormat, extractDateFromGMTDateString} from '../helpers/formatit';
+import {dateCompare} from '../helpers/sortit';
 import summaryMap from './summary.json';
 
 import {getEnv, fetchEnvData} from '../utils/envConfig';
@@ -237,111 +238,133 @@ export default class Landing extends Component {
     alerts.sort(function (a, b) {
       return a.priority - b.priority;
     });
-
+     //process graph data
     let graphConfig = overviewSection.graphConfig;
-    //process graph data
-    if (graphConfig && graphConfig.summaryDataSource) {
-      //get the data from summary data
-      let sections = graphConfig.summaryDataSource;
-      let graph_data = [];
-      let formattedGraphData = [];
-      if (getEnv(graphConfig.demoConfigKey) || graphConfig.useDemo) {
-        graph_data = graphConfig.demoData;
-        summary[overviewSectionKey+"_graph"] = graph_data;
-      } else {
-        sections.forEach(item => {
-          if (summary[item.section_key] && summary[item.section_key][item.subSection_key]) {
-            //console.log("section data? ", summary[item.section_key][item.subSection_key])
-            graph_data = [...graph_data, ...summary[item.section_key][item.subSection_key]];
-          }
-        });
-        let prevObj = null;
-        let o = {};
-        const PLACEHOLDER_FIELD_NAME = "placeholder";
-        const compareDate = (a, b) => {
-          let calcA = (new Date(a["Start"])).getTime();
-          let calcB = (new Date(b["Start"])).getTime();
-          if (calcA > calcB) return 1;
-          if (calcB > calcA) return -1;
-          return 0;
+    if (!(graphConfig && graphConfig.summaryDataSource)) {
+      return;
+    }
+    //get the data from summary data
+    let sections = graphConfig.summaryDataSource;
+    let graph_data = [];
+    if (getEnv(graphConfig.demoConfigKey)) {
+      graph_data = graphConfig.demoData;
+      summary[overviewSectionKey+"_graph"] = graph_data;
+    } else {
+      sections.forEach(item => {
+        if (summary[item.section_key] && summary[item.section_key][item.subSection_key]) {
+          graph_data = [...graph_data, ...summary[item.section_key][item.subSection_key]];
         }
-        graph_data = graph_data.sort(compareDate);
-        /*
-         * processing graph data
-         */
-        graph_data.forEach(function(item, index) {
-          /* make sure dates are in consistent format */
-          let startDate = item[graphConfig.startDateField];
-          if (startDate.indexOf("T") > 0) {
-            startDate = startDate.substring(0, startDate.indexOf("T"));
+      });
+      const [startDateFieldName, endDateFieldName, MMEValueFieldName, graphDateFieldName] = [graphConfig.startDateField, graphConfig.endDateField, graphConfig.mmeField, graphConfig.graphDateField];
+      // const endDateFieldName = graphConfig.endDateField;
+      // const MMEValueFieldName = graphConfig.mmeField;
+      // const graphDateFieldName = graphConfig.graphDateField;
+      const DELIMITER_FIELD_NAME = "delimiter";
+      const PLACEHOLDER_FIELD_NAME = "placeholder";
+
+      graph_data = graph_data.filter(function(item) {
+        return item[startDateFieldName] && item[endDateFieldName];
+      }).sort(function(a, b) {
+        return dateCompare(a[startDateFieldName], b[startDateFieldName]);
+      });
+      console.log("sorted original graph data ", graph_data)
+
+      let dataPoints = [];
+      let prevObj = null, nextObj = null;
+      graph_data.forEach(function(item, index) {
+          let dataPoint = {};
+          let startDate = extractDateFromGMTDateString(item[startDateFieldName]);
+          let endDate = extractDateFromGMTDateString(item[endDateFieldName]);
+          let [oStartDate, oEndDate] = [new Date(startDate), new Date(endDate)];
+          //let oEndDate = new Date(endDate);
+          let diffTime = oEndDate - oStartDate;
+          let diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+          nextObj =  (index+1) <= graph_data.length-1 ? graph_data[index+1]: null;
+          //console.log("start date ", startDate, " end Date ", endDate, " dff days " , diffDays)
+          //add (0, 0) data point to denote start of a new med, only if the start date does not overlap with the end date of the previous med
+          if (!prevObj || (prevObj && (dateNumberFormat(item[startDateFieldName]) >= dateNumberFormat(prevObj[endDateFieldName])))){
+            dataPoint = {};
+            dataPoint[graphDateFieldName] = item[startDateFieldName];
+            dataPoint[MMEValueFieldName] = 0;
+            dataPoint[PLACEHOLDER_FIELD_NAME] = true;
+            dataPoint[DELIMITER_FIELD_NAME] = true;
+            dataPoints.push(dataPoint);
           }
-          let endDate = item[graphConfig.endDateField];
-          if (endDate.indexOf("T") > 0) {
-            endDate = endDate.substring(0, endDate.indexOf("T"));
-          }
-          //baseline point
-          if (index === 0 && item[graphConfig.mmeField] !== 0) {
-            o = {};
-            o[graphConfig.graphDateField]=startDate;
-            o[graphConfig.mmeField] = 0;
-            o[PLACEHOLDER_FIELD_NAME] = true;
-            formattedGraphData.unshift(o);
-          }
-          //add placeholder data points for the period
-          if (prevObj) {
-            if (prevObj[graphConfig.mmeField] !== item[graphConfig.mmeField] || (prevObj[graphConfig.startDateField] !== item[graphConfig.startDateField])) {
-              o = {};
-              o[graphConfig.graphDateField] = prevObj[graphConfig.endDateField];
-              o[graphConfig.mmeField] = 0;
-              o[PLACEHOLDER_FIELD_NAME] = true;
-              formattedGraphData.push(o);
-              o = {};
-              o[graphConfig.graphDateField]=startDate;
-              o[graphConfig.mmeField] = 0;
-              o[PLACEHOLDER_FIELD_NAME] = true;
-              formattedGraphData.push(o);
-            } else {
-              o = {};
-              o[graphConfig.graphDateField]=startDate;
-              o[graphConfig.mmeField] = prevObj[graphConfig.mmeField];
-              o[PLACEHOLDER_FIELD_NAME] = true;
-              formattedGraphData.push(o);
+
+          //add start date data point
+          dataPoint = {};
+          dataPoint[graphDateFieldName] = item[startDateFieldName];
+          dataPoint[MMEValueFieldName] = item[MMEValueFieldName];
+          dataPoints.push(dataPoint);
+
+          //add intermediate data points between start and end dates
+          if (diffDays >= 2) {
+            for (let index = 2; index <= diffDays; index++) {
+              let dataDate = new Date(oStartDate.valueOf());
+              dataDate.setTime(dataDate.getTime() + (index * 24 * 60 * 60 * 1000));
+              dataDate = dateFormat("", dataDate, "YYYY-MM-DD");
+              dataPoint = {};
+              dataPoint[graphDateFieldName] = dataDate;
+              dataPoint[MMEValueFieldName] = item[MMEValueFieldName];
+              dataPoint[PLACEHOLDER_FIELD_NAME] = true;
+              dataPoints.push(dataPoint);
             }
           }
-          //add data point for staring date
-          o = {};
-          o[graphConfig.graphDateField]=startDate;
-          o[graphConfig.mmeField]=item[graphConfig.mmeField];
-          formattedGraphData.push(o);
+          //add end Date data point
+          dataPoint = {};
+          dataPoint[graphDateFieldName] = item[endDateFieldName];
+          dataPoint[MMEValueFieldName] = item[MMEValueFieldName];
+          dataPoints.push(dataPoint);
 
-          //add data point for end date
-          o = {};
-          o[graphConfig.graphDateField] = endDate;
-          o[graphConfig.mmeField] = item[graphConfig.mmeField];
-          formattedGraphData.push(o);
-
-          //data end point
-          if (graph_data.length > 1 &&
-              (index === graph_data.length-1) &&
-              item[graphConfig.mmeField] !== 0) {
-            o = {};
-            o[graphConfig.graphDateField] = endDate;
-            o[graphConfig.mmeField] = 0;
-            o[PLACEHOLDER_FIELD_NAME] = true;
-            formattedGraphData.push(o)
+          //add (0, 0) data point to denote end of medication only if the end date doesn't overlap with the start date of the next medication
+          if (!nextObj || (nextObj && !(dateNumberFormat(item[endDateFieldName]) >= dateNumberFormat(nextObj[startDateFieldName])))) {
+            dataPoint = {};
+            dataPoint[graphDateFieldName] = item[endDateFieldName];
+            dataPoint[MMEValueFieldName] = 0;
+            dataPoint[DELIMITER_FIELD_NAME] = true;
+            dataPoint[PLACEHOLDER_FIELD_NAME] = true;
+            dataPoints.push(dataPoint);
           }
-          prevObj = JSON.parse(JSON.stringify(item));
+          prevObj = item;
+
+      });
+
+      //sort data by date
+      dataPoints = dataPoints.sort(function(a, b) {
+        return dateCompare(a[graphDateFieldName], b[graphDateFieldName]);
+      });
+
+      //get all available dates
+      let arrDates = (dataPoints.map(item => item.date));
+      arrDates = arrDates.filter((d, index) => {
+        return arrDates.indexOf(d) === index;
+      });
+
+      //loop through graph data to ADD MME values for the ones occurring on the same date
+      let cumMMEValue = 0;
+      arrDates.forEach(pointDate => {
+        cumMMEValue = 0;
+        let matchedItems = dataPoints.filter(d => {
+          return d.date === pointDate;
         });
-        summary[overviewSectionKey+"_graph"] = formattedGraphData;
-        console.log("formatted graph data: ", formattedGraphData);
-      }
-
-      //console.log("graph data?? ", graph_data)
+        if (matchedItems.length <= 1) return true;
+        matchedItems.forEach(o => {
+          cumMMEValue += o[MMEValueFieldName];
+        })
+        //console.log("matchedItems ", matchedItems, " cum ", cumMMEValue);
+        dataPoints.forEach((item) => {
+          if (item.date === pointDate && !item[DELIMITER_FIELD_NAME]) { //don't change MME value for (0,0) delimiting data point
+            item[MMEValueFieldName] = cumMMEValue;
+          }
+        });
+      });
+      console.log("graph data ", dataPoints);
+      summary[overviewSectionKey+"_graph"] = dataPoints;
     }
-
-
     summary[overviewSectionKey+"_stats"] = stats;
     summary[overviewSectionKey+"_alerts"] = alerts.filter((item,index,thisRef)=>thisRef.findIndex(t=>(t.text === item.text))===index);
+
+    console.log("summary", summary)
 
   }
 

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -283,7 +283,7 @@ export default class Landing extends Component {
         dataPoint[graphDateFieldName] = currentMedicationItem[startDateFieldName];
         dataPoint[MMEValueFieldName] = currentMedicationItem[MMEValueFieldName];
         //add delimiter flag to denote the start of the medication
-        if ( (prevObj && (dateNumberFormat(currentMedicationItem[startDateFieldName]) > dateNumberFormat(prevObj[endDateFieldName])))) dataPoint[START_DELIMITER_FIELD_NAME] = true;
+        if (!prevObj || (prevObj && (dateNumberFormat(currentMedicationItem[startDateFieldName]) > dateNumberFormat(prevObj[endDateFieldName])))) dataPoint[START_DELIMITER_FIELD_NAME] = true;
         dataPoints.push(dataPoint);
 
         //add intermediate data points between start and end dates
@@ -305,7 +305,7 @@ export default class Landing extends Component {
         dataPoint[graphDateFieldName] = currentMedicationItem[endDateFieldName];
         dataPoint[MMEValueFieldName] = currentMedicationItem[MMEValueFieldName];
         //add delimiter flag to denote the end of the medication
-        if ((nextObj && !(dateNumberFormat(currentMedicationItem[endDateFieldName]) >= dateNumberFormat(nextObj[startDateFieldName])))) dataPoint[END_DELIMITER_FIELD_NAME] = true;
+        if (!nextObj || (nextObj && !(dateNumberFormat(currentMedicationItem[endDateFieldName]) >= dateNumberFormat(nextObj[startDateFieldName])))) dataPoint[END_DELIMITER_FIELD_NAME] = true;
         dataPoints.push(dataPoint);
         prevObj = currentMedicationItem;
 
@@ -345,13 +345,13 @@ export default class Landing extends Component {
       dataPoints.forEach(function(currentDataPoint, index) {
         let dataPoint = {};
         nextObj = dataPoints[index+1] ? dataPoints[index+1]: null;
-        if (index === 0) {
+        /*if (index === 0) {
           dataPoint = {};
           dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
           dataPoint[MMEValueFieldName] = 0;
           dataPoint[PLACEHOLDER_FIELD_NAME] = true;
           finalDataPoints.push(dataPoint);
-        }
+        }*/
          
             //add start delimiting (0, 0) data point
             if (currentDataPoint[START_DELIMITER_FIELD_NAME]) {
@@ -394,13 +394,13 @@ export default class Landing extends Component {
                          
                          
         //add end of line point denoting end of med
-        if (!nextObj) {
+        /*if (!nextObj) {
           dataPoint = {};
           dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
           dataPoint[MMEValueFieldName] = 0;
          dataPoint[PLACEHOLDER_FIELD_NAME] = true;
           finalDataPoints.push(dataPoint);
-        }
+        }*/
         prevObj = currentDataPoint;
       });
       console.log("graph data ", finalDataPoints);

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -305,7 +305,7 @@ export default class Landing extends Component {
         dataPoint[graphDateFieldName] = currentMedicationItem[endDateFieldName];
         dataPoint[MMEValueFieldName] = currentMedicationItem[MMEValueFieldName];
         //add delimiter flag to denote the end of the medication
-        if ((nextObj && !(dateNumberFormat(currentMedicationItem[endDateFieldName]) > dateNumberFormat(nextObj[startDateFieldName])))) dataPoint[END_DELIMITER_FIELD_NAME] = true;
+        if ((nextObj && !(dateNumberFormat(currentMedicationItem[endDateFieldName]) >= dateNumberFormat(nextObj[startDateFieldName])))) dataPoint[END_DELIMITER_FIELD_NAME] = true;
         dataPoints.push(dataPoint);
         prevObj = currentMedicationItem;
 

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -359,7 +359,7 @@ export default class Landing extends Component {
               dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
               dataPoint[MMEValueFieldName] = 0;
               dataPoint[START_DELIMITER_FIELD_NAME] = true;
-              if (!prevObj) dataPoint[PLACEHOLDER_FIELD_NAME] = true;
+              dataPoint[PLACEHOLDER_FIELD_NAME] = true;
               finalDataPoints.push(dataPoint);
               //add current data point
               finalDataPoints.push(currentDataPoint); 
@@ -371,7 +371,7 @@ export default class Landing extends Component {
               dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
               dataPoint[MMEValueFieldName] = 0;
               dataPoint[END_DELIMITER_FIELD_NAME] = true;
-              if (!nextObj) dataPoint[PLACEHOLDER_FIELD_NAME] = true;
+              dataPoint[PLACEHOLDER_FIELD_NAME] = true;
               finalDataPoints.push(dataPoint);
             } else {
               

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -359,8 +359,6 @@ export default class Landing extends Component {
     summary[overviewSectionKey+"_stats"] = stats;
     summary[overviewSectionKey+"_alerts"] = alerts.filter((item,index,thisRef)=>thisRef.findIndex(t=>(t.text === item.text))===index);
 
-    console.log("summary", summary)
-
   }
 
   processEndPoint(endpoint) {

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -283,7 +283,7 @@ export default class Landing extends Component {
         dataPoint[graphDateFieldName] = currentMedicationItem[startDateFieldName];
         dataPoint[MMEValueFieldName] = currentMedicationItem[MMEValueFieldName];
         //add delimiter flag to denote the start of the medication
-        if ((prevObj && (dateNumberFormat(currentMedicationItem[startDateFieldName]) > dateNumberFormat(prevObj[endDateFieldName])))) dataPoint[START_DELIMITER_FIELD_NAME] = true;
+        if (!prevObj || (prevObj && (dateNumberFormat(currentMedicationItem[startDateFieldName]) > dateNumberFormat(prevObj[endDateFieldName])))) dataPoint[START_DELIMITER_FIELD_NAME] = true;
         dataPoints.push(dataPoint);
 
         //add intermediate data points between start and end dates
@@ -305,7 +305,7 @@ export default class Landing extends Component {
         dataPoint[graphDateFieldName] = currentMedicationItem[endDateFieldName];
         dataPoint[MMEValueFieldName] = currentMedicationItem[MMEValueFieldName];
         //add delimiter flag to denote the end of the medication
-        if ((nextObj && !(dateNumberFormat(currentMedicationItem[endDateFieldName]) >= dateNumberFormat(nextObj[startDateFieldName])))) dataPoint[END_DELIMITER_FIELD_NAME] = true;
+        if (!nextObj || (nextObj && !(dateNumberFormat(currentMedicationItem[endDateFieldName]) >= dateNumberFormat(nextObj[startDateFieldName])))) dataPoint[END_DELIMITER_FIELD_NAME] = true;
         dataPoints.push(dataPoint);
         prevObj = currentMedicationItem;
 

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -283,7 +283,7 @@ export default class Landing extends Component {
         dataPoint[graphDateFieldName] = currentMedicationItem[startDateFieldName];
         dataPoint[MMEValueFieldName] = currentMedicationItem[MMEValueFieldName];
         //add delimiter flag to denote the start of the medication
-        if (!prevObj || (prevObj && (dateNumberFormat(currentMedicationItem[startDateFieldName]) > dateNumberFormat(prevObj[endDateFieldName])))) dataPoint[START_DELIMITER_FIELD_NAME] = true;
+        if ( (prevObj && (dateNumberFormat(currentMedicationItem[startDateFieldName]) > dateNumberFormat(prevObj[endDateFieldName])))) dataPoint[START_DELIMITER_FIELD_NAME] = true;
         dataPoints.push(dataPoint);
 
         //add intermediate data points between start and end dates
@@ -305,7 +305,7 @@ export default class Landing extends Component {
         dataPoint[graphDateFieldName] = currentMedicationItem[endDateFieldName];
         dataPoint[MMEValueFieldName] = currentMedicationItem[MMEValueFieldName];
         //add delimiter flag to denote the end of the medication
-        if (!nextObj || (nextObj && !(dateNumberFormat(currentMedicationItem[endDateFieldName]) >= dateNumberFormat(nextObj[startDateFieldName])))) dataPoint[END_DELIMITER_FIELD_NAME] = true;
+        if ((nextObj && !(dateNumberFormat(currentMedicationItem[endDateFieldName]) >= dateNumberFormat(nextObj[startDateFieldName])))) dataPoint[END_DELIMITER_FIELD_NAME] = true;
         dataPoints.push(dataPoint);
         prevObj = currentMedicationItem;
 
@@ -345,13 +345,13 @@ export default class Landing extends Component {
       dataPoints.forEach(function(currentDataPoint, index) {
         let dataPoint = {};
         nextObj = dataPoints[index+1] ? dataPoints[index+1]: null;
-     //   if (index === 0) {
-     //     dataPoint = {};
-     //     dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
-     //     dataPoint[MMEValueFieldName] = 0;
-     //     dataPoint[PLACEHOLDER_FIELD_NAME] = true;
-     //     finalDataPoints.push(dataPoint);
-      //  }
+        if (index === 0) {
+          dataPoint = {};
+          dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
+          dataPoint[MMEValueFieldName] = 0;
+          dataPoint[PLACEHOLDER_FIELD_NAME] = true;
+          finalDataPoints.push(dataPoint);
+        }
          
             //add start delimiting (0, 0) data point
             if (currentDataPoint[START_DELIMITER_FIELD_NAME]) {
@@ -382,7 +382,7 @@ export default class Landing extends Component {
                   dataPoint = {};
                   dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
                   dataPoint[MMEValueFieldName] = prevObj[MMEValueFieldName];
-                 // dataPoint[PLACEHOLDER_FIELD_NAME] = true;
+                  dataPoint[PLACEHOLDER_FIELD_NAME] = true;
                   finalDataPoints.push(dataPoint);
                   currentDataPoint[PLACEHOLDER_FIELD_NAME] = false;
                   finalDataPoints.push(currentDataPoint); 
@@ -394,13 +394,13 @@ export default class Landing extends Component {
                          
                          
         //add end of line point denoting end of med
-      //  if (!nextObj) {
-      //    dataPoint = {};
-      //    dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
-      //    dataPoint[MMEValueFieldName] = 0;
-       //   dataPoint[PLACEHOLDER_FIELD_NAME] = true;
-      //    finalDataPoints.push(dataPoint);
-      //  }
+        if (!nextObj) {
+          dataPoint = {};
+          dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
+          dataPoint[MMEValueFieldName] = 0;
+         dataPoint[PLACEHOLDER_FIELD_NAME] = true;
+          finalDataPoints.push(dataPoint);
+        }
         prevObj = currentDataPoint;
       });
       console.log("graph data ", finalDataPoints);

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -352,17 +352,7 @@ export default class Landing extends Component {
           dataPoint[PLACEHOLDER_FIELD_NAME] = true;
           finalDataPoints.push(dataPoint);
         }
-        if (prevObj && prevObj[MMEValueFieldName] !== currentDataPoint[MMEValueFieldName]) {
-          //add data point with older value for the previous med
-          prevObj[PLACEHOLDER_FIELD_NAME] = false;
-          dataPoint = {};
-          dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
-          dataPoint[MMEValueFieldName] = prevObj[MMEValueFieldName];
-          dataPoint[PLACEHOLDER_FIELD_NAME] = true;
-          finalDataPoints.push(dataPoint);
-          currentDataPoint[PLACEHOLDER_FIELD_NAME] = false;
-          finalDataPoints.push(currentDataPoint);
-        } else {
+         
             //add start delimiting (0, 0) data point
             if (currentDataPoint[START_DELIMITER_FIELD_NAME]) {
               dataPoint = {};
@@ -371,22 +361,36 @@ export default class Landing extends Component {
               dataPoint[START_DELIMITER_FIELD_NAME] = true;
               dataPoint[PLACEHOLDER_FIELD_NAME] = true;
               finalDataPoints.push(dataPoint);
+              //add current data point
+              finalDataPoints.push(currentDataPoint); 
             }
-            //add current data point
-            finalDataPoints.push(currentDataPoint);
-
             //add end delimiting (0, 0) data point
-            if (currentDataPoint[END_DELIMITER_FIELD_NAME]) {
-              //finalDataPoints.push(currentDataPoint);
+            else if (currentDataPoint[END_DELIMITER_FIELD_NAME]) {
+              finalDataPoints.push(currentDataPoint);
               dataPoint = {};
               dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
               dataPoint[MMEValueFieldName] = 0;
               dataPoint[END_DELIMITER_FIELD_NAME] = true;
               dataPoint[PLACEHOLDER_FIELD_NAME] = true;
               finalDataPoints.push(dataPoint);
+            } else {
+              
+              if (prevObj && prevObj[MMEValueFieldName] !== currentDataPoint[MMEValueFieldName]) {
+                  //add data point with older value for the previous med
+                  prevObj[PLACEHOLDER_FIELD_NAME] = false;
+                  dataPoint = {};
+                  dataPoint[graphDateFieldName] = currentDataPoint[graphDateFieldName];
+                  dataPoint[MMEValueFieldName] = prevObj[MMEValueFieldName];
+                  dataPoint[PLACEHOLDER_FIELD_NAME] = true;
+                  finalDataPoints.push(dataPoint);
+                  currentDataPoint[PLACEHOLDER_FIELD_NAME] = false;
+                  finalDataPoints.push(currentDataPoint);
+               }
+              
             }
-
-        }
+  
+                         
+                         
         //add end of line point denoting end of med
         if (!nextObj) {
           dataPoint = {};

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -275,9 +275,9 @@ export default class Landing extends Component {
           let [oStartDate, oEndDate] = [new Date(startDate), new Date(endDate)];
           let diffTime = oEndDate - oStartDate;
           let diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-          nextObj =  (index+1) <= graph_data.length-1 ? graph_data[index+1]: null;
+          nextObj = (index+1) <= graph_data.length-1 ? graph_data[index+1]: null;
 
-          //add (0, 0) data point to denote start of a new med, only if the start date does not overlap with the end date of the previous med
+          //add (0, 0) data point to denote the start of a new med, only if the start date does not overlap with the end date of the previous med
           if (!prevObj || (prevObj && (dateNumberFormat(item[startDateFieldName]) >= dateNumberFormat(prevObj[endDateFieldName])))){
             dataPoint = {};
             dataPoint[graphDateFieldName] = item[startDateFieldName];
@@ -348,7 +348,7 @@ export default class Landing extends Component {
           cumMMEValue += o[MMEValueFieldName];
         });
         dataPoints.forEach((item) => {
-          if (item.date === pointDate && !item[DELIMITER_FIELD_NAME]) { //don't change MME value for (0,0) delimiting data point
+          if (item.date === pointDate && !item[DELIMITER_FIELD_NAME]) { //don't change MME value for (0,0) delimiting data points, which connect to the start and end MME values for each medication, as displayed by vertical connecting lines
             item[MMEValueFieldName] = cumMMEValue;
           }
         });

--- a/src/components/Summary.js
+++ b/src/components/Summary.js
@@ -530,7 +530,7 @@ export default class Summary extends Component {
     const {EducationMaterials,
       PatientRiskOverview_graph,
       PatientRiskOverview_alerts,
-      PatientRiskOverview_stats, ...devToolSummary} = summary;
+      PatientRiskOverview_stats, ...CQLSummary} = summary;
     if (!summary) { return null; }
 
     const sectionsToRender = [];
@@ -609,7 +609,7 @@ export default class Summary extends Component {
 
           <DevTools
             collector={collector}
-            summary={devToolSummary}
+            summary={CQLSummary}
             //results not coming from CQL
             other={{EducationMaterials, PatientRiskOverview_graph, PatientRiskOverview_alerts, PatientRiskOverview_stats}}
           />

--- a/src/components/Summary.js
+++ b/src/components/Summary.js
@@ -134,6 +134,7 @@ export default class Summary extends Component {
     const { sectionFlags } = this.props;
 
     let flagged = false;
+    if (!sectionFlags[section][subSection]) return false;
     sectionFlags[section][subSection].forEach((flag) => {
       if (flag.entryId === entry._id) {
         flagged = flag.flagText;
@@ -193,7 +194,7 @@ export default class Summary extends Component {
           <div>no entries found</div>
             <div className="flag-guideline-content">
               <div>{flagContent}</div>
-              {guidelineContent && 
+              {guidelineContent &&
               <div className="guideline-content">
                 {guidelineContent}
               </div>}
@@ -202,7 +203,7 @@ export default class Summary extends Component {
       </div>
     );
   }
- 
+
   renderTable(table, entries, section, subSection, index) {
     // If a filter is provided, only render those things that have the filter field (or don't have it when it's negated)
     let filteredEntries = entries;
@@ -459,7 +460,7 @@ export default class Summary extends Component {
     const flaggedClass = flagged ? 'flagged' : '';
     const flagCount = this.getSectionFlagCount(section);
     const flaggedText = flagged? `${flagCount ? flagCount + ' flag entr' + (flagCount > 1?'ies': 'y') + ' found': ''}` : "";
-  
+
     let icon = '';
     let sourceTitle = summaryMap[section]['title'];
     let title = sourceTitle;
@@ -504,7 +505,7 @@ export default class Summary extends Component {
             {title}
             <span className="info">
               {entryCount && entryCount}
-              <FontAwesomeIcon 
+              <FontAwesomeIcon
                 className={`flag flag-header ${flaggedClass}`}
                 icon="exclamation-circle"
                 title={flaggedText}
@@ -524,8 +525,12 @@ export default class Summary extends Component {
   };
 
   render() {
-    const { summary, collector, result } = this.props;
+    const { summary, collector } = this.props;
     const meetsInclusionCriteria = summary.Patient.MeetsInclusionCriteria;
+    const {EducationMaterials,
+      PatientRiskOverview_graph,
+      PatientRiskOverview_alerts,
+      PatientRiskOverview_stats, ...devToolSummary} = summary;
     if (!summary) { return null; }
 
     const sectionsToRender = [];
@@ -536,14 +541,14 @@ export default class Summary extends Component {
       sectionsToRender.push(section);
     });
 
-    const navToggleToolTip = this.state.showNav ? "collapse side navigation menu" : "expand side navigation menu"; 
+    const navToggleToolTip = this.state.showNav ? "collapse side navigation menu" : "expand side navigation menu";
 
     return (
       <div className="summary">
         <div className={`${this.state.showNav?'open': ''} summary__nav-wrapper`}>
           <ReactTooltip className="summary-tooltip" id="navTooltip" />
           <nav className="summary__nav"></nav>
-          <div 
+          <div
             ref={ref => this.navRef = ref}
             data-for="navTooltip"
             data-tip={navToggleToolTip}
@@ -604,8 +609,9 @@ export default class Summary extends Component {
 
           <DevTools
             collector={collector}
-            result={result}
-            summary={summary}
+            summary={devToolSummary}
+            //results not coming from CQL
+            other={{EducationMaterials, PatientRiskOverview_graph, PatientRiskOverview_alerts, PatientRiskOverview_stats}}
           />
 
           <ReactModal

--- a/src/components/graph/MMEGraph.js
+++ b/src/components/graph/MMEGraph.js
@@ -167,7 +167,7 @@ export default class MMEGraph extends Component {
       additionalProps["dataPoints"] = {
         "strokeColor": "#217684",
         "strokeFill": "#217684",
-        "strokeWidth": 1.5
+        "strokeWidth": 2.5
       }
     //}
 

--- a/src/components/summary.json
+++ b/src/components/summary.json
@@ -25,7 +25,6 @@
     },
     "graphConfig": {
       "demoConfigKey": "USE_DEMO",
-      "useDemo": false,
       "graphDateField": "date",
       "mmeField": "MMEValue",
       "startDateField": "Start",
@@ -115,6 +114,7 @@
             "headers": {
               "Drug Description": "Name",
               "Quantity": "Quantity",
+              "Duration": "Duration",
               "Written Date": { "key": "Start", "formatter": "datishFormat", "sorter": "dateTimeFormat" },
               "Dispensed": { "key": "End", "formatter": "datishFormat", "sorter": "dateTimeFormat" },
               "Prescriber": "Prescriber",

--- a/src/cql/r4/Factors_to_Consider_in_Managing_Chronic_Pain_FHIRv400.cql
+++ b/src/cql/r4/Factors_to_Consider_in_Managing_Chronic_Pain_FHIRv400.cql
@@ -613,6 +613,7 @@ define ReportPDMPMedicationRequests:
       CalculatedEnd: CalculatedEnd, //of datetime type
       End: ToString(CalculatedEnd), //of string type
       Quantity: if dispenseRequest is not null then dispenseRequest.quantity.value.value else null,
+      Duration: if dispenseRequest.expectedSupplyDuration is not null then dispenseRequest.expectedSupplyDuration.value.value else null,
       Prescriber: O.requester.display.value,
       Pharmacy: (O.dispenseRequest.extension[0].value as FHIR.string).value,
       Status: O.status.value
@@ -801,7 +802,7 @@ define ReportMMEByDates:
   return {
     Start: R.Start,
     End: R.End,
-    MMEValue: Sum(ReportMME M where M.End ~ R.End return M.MMEValue)
+    MMEValue: First(ReportMME M where M.Start ~ R.Start return M.MMEValue)
   }
   sort by End
 

--- a/src/cql/r4/Factors_to_Consider_in_Managing_Chronic_Pain_FHIRv400.json
+++ b/src/cql/r4/Factors_to_Consider_in_Managing_Chronic_Pain_FHIRv400.json
@@ -4031,6 +4031,52 @@
                            }
                         }
                      }, {
+                        "name" : "Duration",
+                        "value" : {
+                           "type" : "If",
+                           "condition" : {
+                              "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                              "type" : "As",
+                              "operand" : {
+                                 "type" : "Not",
+                                 "operand" : {
+                                    "type" : "IsNull",
+                                    "operand" : {
+                                       "path" : "expectedSupplyDuration",
+                                       "type" : "Property",
+                                       "source" : {
+                                          "name" : "dispenseRequest",
+                                          "type" : "QueryLetRef"
+                                       }
+                                    }
+                                 }
+                              }
+                           },
+                           "then" : {
+                              "path" : "value",
+                              "type" : "Property",
+                              "source" : {
+                                 "path" : "value",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "path" : "expectedSupplyDuration",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "dispenseRequest",
+                                       "type" : "QueryLetRef"
+                                    }
+                                 }
+                              }
+                           },
+                           "else" : {
+                              "asType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                              "type" : "As",
+                              "operand" : {
+                                 "type" : "Null"
+                              }
+                           }
+                        }
+                     }, {
                         "name" : "Prescriber",
                         "value" : {
                            "path" : "value",
@@ -5621,7 +5667,7 @@
                      }, {
                         "name" : "MMEValue",
                         "value" : {
-                           "type" : "Sum",
+                           "type" : "First",
                            "source" : {
                               "type" : "Query",
                               "source" : [ {
@@ -5635,11 +5681,11 @@
                               "where" : {
                                  "type" : "Equivalent",
                                  "operand" : [ {
-                                    "path" : "End",
+                                    "path" : "Start",
                                     "scope" : "M",
                                     "type" : "Property"
                                  }, {
-                                    "path" : "End",
+                                    "path" : "Start",
                                     "scope" : "R",
                                     "type" : "Property"
                                  } ]

--- a/src/cql/r4/MMECalculator.cql
+++ b/src/cql/r4/MMECalculator.cql
@@ -82,6 +82,7 @@ define function GetMedicationQuantity(medication MedicationRequest):
                 then OMTKLogic.ToUCUM(prescription.strength.unit) else null,
       doseQuantity:
               case
+                //look for dosage instruction first
                 when dosage is not null and dosage.high is null then
                   System.Quantity {
                       value: dosage.value.value,

--- a/src/helpers/formatit.js
+++ b/src/helpers/formatit.js
@@ -12,6 +12,23 @@ export function dateFormat(result, input, format) {
   return moment.parseZone(input).format(format);
 }
 
+/*
+ * assume date in YYYY-MM-DD formate
+ * return date to number format, 19901112
+ */
+export function dateNumberFormat(input) {
+  if (!input) return "";
+  return parseFloat(input.replace(/-/g, ""));
+}
+
+export function extractDateFromGMTDateString(dateString) {
+  if (!dateString) return "";
+  if (dateString.indexOf("T") > 0) {
+    return dateString.substring(0, dateString.indexOf("T"));
+  }
+  return dateString;
+}
+
 export function currentDateTimeFormat() {
   return moment().format("MMMM Do YYYY, h:mm:ss a");
 }
@@ -92,7 +109,7 @@ export function stringSubstitutionFormat(result, input, replacement) {
   return replacement;
 }
 /*
- * format input as a anchor link or embed video link 
+ * format input as a anchor link or embed video link
  */
 export function linkFormat(result, input) {
   let isVideoLink = input['type'] === 'video' && input['embedVideoSrc'];
@@ -104,7 +121,7 @@ export function linkFormat(result, input) {
           toggleable={true}
         />
     );
-  } 
+  }
   return (
     <div className="link-container">
       <a href={input['url']} title={input['title']} target='_blank' rel='noopener noreferrer' className={input['className']}>{input['title']}</a>
@@ -151,7 +168,7 @@ export function codeableConceptFormat(result, input, key, field, codingField, co
   if (!input) {
     return '';
   }
-  if (typeof input === 'object' && 
+  if (typeof input === 'object' &&
       typeof input[key] === 'string') {
     return input[key];
   }

--- a/src/helpers/formatit.js
+++ b/src/helpers/formatit.js
@@ -21,6 +21,9 @@ export function dateNumberFormat(input) {
   return parseFloat(input.replace(/-/g, ""));
 }
 
+/*
+ * return date part of the GMT date string, e.g. 10/12/1999 from 10/12/1999T12:12:22
+ */
 export function extractDateFromGMTDateString(dateString) {
   if (!dateString) return "";
   if (dateString.indexOf("T") > 0) {

--- a/src/styles/components/_Summary.scss
+++ b/src/styles/components/_Summary.scss
@@ -741,7 +741,8 @@
       .fhir-queries,
       .cql-results,
       .pdmp-results,
-      .occupation-results {
+      .occupation-results,
+      .other-results {
         margin-left: 40px;
       }
 

--- a/src/utils/r4_test_patients/brenda_jackson.json
+++ b/src/utils/r4_test_patients/brenda_jackson.json
@@ -717,50 +717,7 @@
             }
           ]
         },
-        "authoredOn": "2020-09-05",
-        "dosageInstruction": [
-          {
-            "timing": {
-              "repeat": {
-                "frequency": 1,
-                "period": 30.0,
-                "periodUnit": "d"
-              }
-            },
-            "asNeededBoolean": false,
-            "doseAndRate": [
-              {
-                "doseRange": {
-                  "low": {
-                    "value": 1,
-                    "system": "http://unitsofmeasure.org",
-                    "code": "mg/(72.h)",
-                    "unit": "mg/(72.h)"
-                  },
-                  "high": {
-                    "value": 3,
-                    "system": "http://unitsofmeasure.org",
-                    "code": "mg/(72.h)",
-                    "unit": "mg/(72.h)"
-                  }
-                }
-              }
-            ]
-          }
-        ],
-        "dispenseRequest": {
-          "validityPeriod": {
-            "start": "2020-09-05",
-            "end": "2020-12-25"
-          },
-          "numberOfRepeatsAllowed": 1,
-          "expectedSupplyDuration": {
-            "value": 30,
-            "unit": "days",
-            "system": "http://unitsofmeasure.org",
-            "code": "d"
-          }
-        }
+        "authoredOn": "2020-09-05"
       }
     },
     {
@@ -780,41 +737,6 @@
               "display": "72 HR Fentanyl 0.075 MG/HR Transdermal System"
             }
           ]
-        },
-        "dosageInstruction": [
-          {
-            "timing": {
-              "repeat": {
-                "frequency": 1,
-                "period": 3.0,
-                "periodUnit": "d"
-              }
-            },
-            "asNeededBoolean": false,
-            "doseAndRate": [
-              {
-                "doseQuantity": {
-                  "value": 1.0,
-                  "system": "http://unitsofmeasure.org",
-                  "code": "mg/(72.h)",
-                  "unit": "mg/(72.h)"
-                }
-              }
-            ]
-          }
-        ],
-        "dispenseRequest": {
-          "validityPeriod": {
-            "start": "2018-07-15",
-            "end": "2018-08-25"
-          },
-          "numberOfRepeatsAllowed": 3,
-          "expectedSupplyDuration": {
-            "value": 30,
-            "unit": "days",
-            "system": "http://unitsofmeasure.org",
-            "code": "d"
-          }
         },
         "authoredOn": "2018-07-15T16:02:00.000Z"
       }
@@ -838,41 +760,6 @@
           ],
           "text": "12 HR Oxycodone Hydrochloride 60 MG Extended Release Oral Tablet"
         },
-        "dosageInstruction": [
-          {
-            "timing": {
-              "repeat": {
-                "frequency": 1,
-                "period": 1.0,
-                "periodUnit": "d"
-              }
-            },
-            "asNeededBoolean": false,
-            "doseAndRate": [
-              {
-                "doseQuantity": {
-                  "value": 1.0,
-                  "system": "http://unitsofmeasure.org",
-                  "code": "mg",
-                  "unit": "mg"
-                }
-              }
-            ]
-          }
-        ],
-        "dispenseRequest": {
-          "validityPeriod": {
-            "start": "2018-07-15",
-            "end": "2018-07-15"
-          },
-          "numberOfRepeatsAllowed": 1,
-          "expectedSupplyDuration": {
-            "value": 1,
-            "unit": "days",
-            "system": "http://unitsofmeasure.org",
-            "code": "d"
-          }
-        },
         "authoredOn": "2018-07-15T16:02:00.000Z"
       }
     },
@@ -895,41 +782,6 @@
           ],
           "text": "12 HR Oxycodone Hydrochloride 60 MG Extended Release Oral Tablet"
         },
-        "dosageInstruction": [
-          {
-            "timing": {
-              "repeat": {
-                "frequency": 1,
-                "period": 1.0,
-                "periodUnit": "d"
-              }
-            },
-            "asNeededBoolean": false,
-            "doseAndRate": [
-              {
-                "doseQuantity": {
-                  "value": 1.0,
-                  "system": "http://unitsofmeasure.org",
-                  "code": "mg",
-                  "unit": "mg"
-                }
-              }
-            ]
-          }
-        ],
-        "dispenseRequest": {
-          "validityPeriod": {
-            "start": "2018-07-15",
-            "end": "2018-07-15"
-          },
-          "numberOfRepeatsAllowed": 1,
-          "expectedSupplyDuration": {
-            "value": 1,
-            "unit": "days",
-            "system": "http://unitsofmeasure.org",
-            "code": "d"
-          }
-        },
         "authoredOn": "2018-07-15T16:02:00.000Z"
       }
     },
@@ -951,41 +803,6 @@
             }
           ],
           "text": "12 HR Oxycodone Hydrochloride 60 MG Extended Release Oral Tablet"
-        },
-        "dosageInstruction": [
-          {
-            "timing": {
-              "repeat": {
-                "frequency": 1,
-                "period": 1.0,
-                "periodUnit": "d"
-              }
-            },
-            "asNeededBoolean": false,
-            "doseAndRate": [
-              {
-                "doseQuantity": {
-                  "value": 1.0,
-                  "system": "http://unitsofmeasure.org",
-                  "code": "mg",
-                  "unit": "mg"
-                }
-              }
-            ]
-          }
-        ],
-        "dispenseRequest": {
-          "validityPeriod": {
-            "start": "2019-07-15",
-            "end": "2019-07-15"
-          },
-          "numberOfRepeatsAllowed": 1,
-          "expectedSupplyDuration": {
-            "value": 1,
-            "unit": "days",
-            "system": "http://unitsofmeasure.org",
-            "code": "d"
-          }
         },
         "authoredOn": "2019-07-15T16:02:00.000Z"
       }
@@ -1010,28 +827,6 @@
           ],
           "text": "12 HR Oxycodone Hydrochloride 60 MG Extended Release Oral Tablet"
         },
-        "dosageInstruction": [
-          {
-            "timing": {
-              "repeat": {
-                "frequency": 1,
-                "period": 1.0,
-                "periodUnit": "d"
-              }
-            },
-            "asNeededBoolean": false,
-            "doseAndRate": [
-              {
-                "doseQuantity": {
-                  "value": 1.0,
-                  "system": "http://unitsofmeasure.org",
-                  "code": "mg",
-                  "unit": "mg"
-                }
-              }
-            ]
-          }
-        ],
         "authoredOn": "2020-05-15T16:02:00.000Z"
       }
     },
@@ -1055,28 +850,6 @@
           ],
           "text": "12 HR Oxycodone Hydrochloride 60 MG Extended Release Oral Tablet"
         },
-        "dosageInstruction": [
-          {
-            "timing": {
-              "repeat": {
-                "frequency": 1,
-                "period": 1.0,
-                "periodUnit": "d"
-              }
-            },
-            "asNeededBoolean": false,
-            "doseAndRate": [
-              {
-                "doseQuantity": {
-                  "value": 1.0,
-                  "system": "http://unitsofmeasure.org",
-                  "code": "mg",
-                  "unit": "mg"
-                }
-              }
-            ]
-          }
-        ],
         "authoredOn": "2017-07-15T16:02:00.000Z"
       }
     },
@@ -1100,28 +873,6 @@
           ],
           "text": "12 HR Oxycodone Hydrochloride 60 MG Extended Release Oral Tablet"
         },
-        "dosageInstruction": [
-          {
-            "timing": {
-              "repeat": {
-                "frequency": 1,
-                "period": 1.0,
-                "periodUnit": "d"
-              }
-            },
-            "asNeededBoolean": false,
-            "doseAndRate": [
-              {
-                "doseQuantity": {
-                  "value": 1.0,
-                  "system": "http://unitsofmeasure.org",
-                  "code": "mg",
-                  "unit": "mg"
-                }
-              }
-            ]
-          }
-        ],
         "authoredOn": "2017-04-15T16:02:00.000Z"
       }
     },
@@ -1145,28 +896,6 @@
           ],
           "text": "12 HR Oxycodone Hydrochloride 60 MG Extended Release Oral Tablet"
         },
-        "dosageInstruction": [
-          {
-            "timing": {
-              "repeat": {
-                "frequency": 1,
-                "period": 1.0,
-                "periodUnit": "d"
-              }
-            },
-            "asNeededBoolean": false,
-            "doseAndRate": [
-              {
-                "doseQuantity": {
-                  "value": 1.0,
-                  "system": "http://unitsofmeasure.org",
-                  "code": "mg",
-                  "unit": "mg"
-                }
-              }
-            ]
-          }
-        ],
         "authoredOn": "2017-01-15T16:02:00.000Z"
       }
     },
@@ -1190,28 +919,6 @@
           ],
           "text": "12 HR Oxycodone Hydrochloride 60 MG Extended Release Oral Tablet"
         },
-        "dosageInstruction": [
-          {
-            "timing": {
-              "repeat": {
-                "frequency": 1,
-                "period": 1.0,
-                "periodUnit": "d"
-              }
-            },
-            "asNeededBoolean": false,
-            "doseAndRate": [
-              {
-                "doseQuantity": {
-                  "value": 1.0,
-                  "system": "http://unitsofmeasure.org",
-                  "code": "mg",
-                  "unit": "mg"
-                }
-              }
-            ]
-          }
-        ],
         "authoredOn": "2019-10-15T16:02:00.000Z"
       }
     },
@@ -1233,49 +940,6 @@
             }
           ],
           "text": "Oxycodone Hydrochloride 10 MG Oral Capsule"
-        },
-        "dosageInstruction": [
-          {
-            "timing": {
-              "repeat": {
-                "frequency": 1,
-                "period": 1.0,
-                "periodUnit": "d"
-              }
-            },
-            "asNeededBoolean": false,
-            "doseAndRate": [
-              {
-                "doseRange": {
-                  "low": {
-                    "value": 1,
-                    "system": "http://unitsofmeasure.org",
-                    "code": "mg",
-                    "unit": "mg"
-                  },
-                  "high": {
-                    "value": 1,
-                    "system": "http://unitsofmeasure.org",
-                    "code": "mg",
-                    "unit": "mg"
-                  }
-                }
-              }
-            ]
-          }
-        ],
-        "dispenseRequest": {
-          "validityPeriod": {
-            "start": "2018-07-15",
-            "end": "2018-07-15"
-          },
-          "numberOfRepeatsAllowed": 1,
-          "expectedSupplyDuration": {
-            "value": 1,
-            "unit": "days",
-            "system": "http://unitsofmeasure.org",
-            "code": "d"
-          }
         },
         "authoredOn": "2018-07-15T16:01:00.000Z"
       }
@@ -1300,47 +964,12 @@
           ],
           "text": "Oxycodone Hydrochloride 10 MG Oral Capsule"
         },
-        "dosageInstruction": [
-          {
-            "timing": {
-              "repeat": {
-                "frequency": 1,
-                "period": 1.0,
-                "periodUnit": "d"
-              }
-            },
-            "asNeededBoolean": false,
-            "doseAndRate": [
-              {
-                "doseQuantity": {
-                  "value": 2.0,
-                  "system": "http://unitsofmeasure.org",
-                  "code": "mg",
-                  "unit": "mg"
-                }
-              }
-            ]
-          }
-        ],
-        "dispenseRequest": {
-          "validityPeriod": {
-            "start": "2019-01-15",
-            "end": "2019-01-15"
-          },
-          "numberOfRepeatsAllowed": 1,
-          "expectedSupplyDuration": {
-            "value": 1,
-            "unit": "days",
-            "system": "http://unitsofmeasure.org",
-            "code": "d"
-          }
-        },
         "authoredOn": "2019-01-15T16:01:00.000Z"
       }
     },
     {
       "resource": {
-        "authoredOn": "2019-10-25",
+        "authoredOn": "2020-10-01",
         "id": "20f04037-b4ed-46ac-9222-c11f1e54580f",
         "subject": {
           "reference": "Patient/5c41cecf-cf81-434f-9da7-e24e5a99dbc2"
@@ -1350,14 +979,14 @@
             "doseAndRate": [
               {
                 "doseQuantity": {
-                  "value": 1.0
+                  "value": 1
                 }
               }
             ],
             "timing": {
               "repeat": {
-                "frequency": 1.0,
-                "period": 1.0,
+                "frequency": 3,
+                "period": 1,
                 "periodUnit": "d"
               }
             }
@@ -1368,20 +997,20 @@
             "code": "d",
             "system": "http://unitsofmeasure.org",
             "unit": "days",
-            "value": 10.0
+            "value": 10
           },
           "extension": [
             {
               "url": "http://cosri.org/fhir/pharmacy_name",
-              "valueString": "TEST, DOCTOR"
+              "valueString": "Corner Drugstore, Kirkland"
             },
             {
               "url": "http://cosri.org/fhir/last_fill",
-              "valueDate": "2019-10-01"
+              "valueDate": "2020-10-01"
             }
           ],
           "quantity": {
-            "value": 30.0
+            "value": 30
           }
         },
         "identifier": [
@@ -1392,27 +1021,27 @@
         "medicationCodeableConcept": {
           "coding": [
             {
-              "code": "49999084830",
-              "display": "morphine sulfate 15 MG Oral Tablet",
+              "code": "13107005530",
+              "display": "oxycodone hydrochloride 5 MG Oral Tablet",
               "system": "http://hl7.org/fhir/sid/ndc"
             },
             {
-              "code": "892582",
-              "display": "morphine sulfate 15 MG Oral Tablet",
+              "code": "1049621",
+              "display": "oxycodone hydrochloride 5 MG Oral Tablet",
               "system": "http://www.nlm.nih.gov/research/umls/rxnorm"
             }
           ],
-          "text": "morphine sulfate 15 MG Oral Tablet"
+          "text": "oxycodone hydrochloride 5 MG Oral Tablet"
         },
         "requester": {
-          "display": "TEST PRESCRIBER"
+          "display": "Sue Prescriber"
         },
         "resourceType": "MedicationRequest"
       }
     },
     {
       "resource": {
-        "authoredOn": "2020-10-25",
+        "authoredOn": "2020-11-03",
         "id": "3e14d51b-58d8-4e7a-b9e3-26893e5604d2",
         "subject": {
           "reference": "Patient/5c41cecf-cf81-434f-9da7-e24e5a99dbc2"
@@ -1422,14 +1051,14 @@
             "doseAndRate": [
               {
                 "doseQuantity": {
-                  "value": 3.0
+                  "value": 1
                 }
               }
             ],
             "timing": {
               "repeat": {
-                "frequency": 15.0,
-                "period": 15.0,
+                "frequency": 3,
+                "period": 1,
                 "periodUnit": "d"
               }
             }
@@ -1440,20 +1069,20 @@
             "code": "d",
             "system": "http://unitsofmeasure.org",
             "unit": "days",
-            "value": 15.0
+            "value": 10
           },
           "extension": [
             {
               "url": "http://cosri.org/fhir/pharmacy_name",
-              "valueString": "TEST, DOCTOR"
+              "valueString": "Seattle Hospital ED"
             },
             {
               "url": "http://cosri.org/fhir/last_fill",
-              "valueDate": "2020-10-25"
+              "valueDate": "2020-11-03"
             }
           ],
           "quantity": {
-            "value": 90.0
+            "value": 30
           }
         },
         "identifier": [
@@ -1464,114 +1093,166 @@
         "medicationCodeableConcept": {
           "coding": [
             {
-              "code": "49999084830",
-              "display": "morphine sulfate 15 MG Oral Tablet",
+              "code": "13107005530",
+              "display": "oxycodone hydrochloride 5 MG Oral Tablet",
               "system": "http://hl7.org/fhir/sid/ndc"
             },
             {
-              "code": "892582",
-              "display": "morphine sulfate 15 MG Oral Tablet",
+              "code": "1049621",
+              "display": "oxycodone hydrochloride 5 MG Oral Tablet",
               "system": "http://www.nlm.nih.gov/research/umls/rxnorm"
             }
           ],
-          "text": "morphine sulfate 15 MG Oral Tablet"
+          "text": "oxycodone hydrochloride 5 MG Oral Tablet"
         },
         "requester": {
-          "display": "TEST PRESCRIBER"
+          "display": "Resident Prescriber"
         },
         "resourceType": "MedicationRequest"
       }
     },
     {
       "resource": {
-        "resourceType": "MedicationRequest",
+        "authoredOn": "2020-11-07",
         "id": "7f4125ed-083c-4071-b02f-eff58f209dce",
         "subject": {
           "reference": "Patient/5c41cecf-cf81-434f-9da7-e24e5a99dbc2"
         },
-        "status": "active",
-        "intent": "order",
-        "doNotPerform": false,
+        "dosageInstruction": [
+          {
+            "doseAndRate": [
+              {
+                "doseQuantity": {
+                  "value": 1
+                }
+              }
+            ],
+            "timing": {
+              "repeat": {
+                "frequency": 2,
+                "period": 1,
+                "periodUnit": "d"
+              }
+            }
+          }
+        ],
+        "dispenseRequest": {
+          "expectedSupplyDuration": {
+            "code": "d",
+            "system": "http://unitsofmeasure.org",
+            "unit": "days",
+            "value": 45
+          },
+          "extension": [
+            {
+              "url": "http://cosri.org/fhir/pharmacy_name",
+              "valueString": "Seattle Ortho Clinic"
+            },
+            {
+              "url": "http://cosri.org/fhir/last_fill",
+              "valueDate": "2020-11-07"
+            }
+          ],
+          "quantity": {
+            "value": 90
+          }
+        },
+        "identifier": [
+          {
+            "system": "https://github.com/uwcirg/script-fhir-facade/"
+          }
+        ],
         "medicationCodeableConcept": {
           "coding": [
             {
-              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-              "code": "1049717",
-              "display": "Oxycodone Hydrochloride 10 MG Oral Capsule"
+              "code": "13107004301",
+              "display": "acetaminophen 325 MG / oxycodone hydrochloride 2.5 MG Oral Tablet",
+              "system": "http://hl7.org/fhir/sid/ndc"
+            },
+            {
+              "code": "1049635",
+              "display": "acetaminophen 325 MG / oxycodone hydrochloride 2.5 MG Oral Tablet",
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm"
             }
           ],
-          "text": "Oxycodone Hydrochloride 10 MG Oral Capsule"
+          "text": "acetaminophen 325 MG / oxycodone hydrochloride 2.5 MG Oral Tablet"
         },
-        "authoredOn": "2018-04-15T16:01:00.000Z"
+        "requester": {
+          "display": "Bone Prescriber"
+        },
+        "resourceType": "MedicationRequest"
       }
     },
     {
       "resource": {
-        "resourceType": "MedicationRequest",
-        "id": "bf8db44f-735a-4624-8e5f-d0b583455c8c",
-        "subject": {
-          "reference": "Patient/5c41cecf-cf81-434f-9da7-e24e5a99dbc2"
-        },
-        "status": "active",
-        "intent": "order",
-        "doNotPerform": false,
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-              "code": "1049717",
-              "display": "Oxycodone Hydrochloride 10 MG Oral Capsule"
-            }
-          ],
-          "text": "Oxycodone Hydrochloride 10 MG Oral Capsule"
-        },
-        "authoredOn": "2018-01-15T16:01:00.000Z"
-      }
-    },
-    {
-      "resource": {
-        "resourceType": "MedicationRequest",
-        "id": "ffc8eb65-0b29-4029-85b4-ab4df2a43360",
-        "subject": {
-          "reference": "Patient/5c41cecf-cf81-434f-9da7-e24e5a99dbc2"
-        },
-        "status": "active",
-        "intent": "order",
-        "doNotPerform": false,
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-              "code": "1049717",
-              "display": "Oxycodone Hydrochloride 10 MG Oral Capsule"
-            }
-          ],
-          "text": "Oxycodone Hydrochloride 10 MG Oral Capsule"
-        },
-        "authoredOn": "2017-10-15T16:01:00.000Z"
-      }
-    },
-    {
-      "resource": {
-        "resourceType": "MedicationRequest",
+        "authoredOn": "2020-11-20",
         "id": "fdb413e1-6c40-4ce4-b9e5-8654daf6cc4f",
         "subject": {
           "reference": "Patient/5c41cecf-cf81-434f-9da7-e24e5a99dbc2"
         },
-        "status": "active",
-        "intent": "order",
-        "doNotPerform": false,
+        "dosageInstruction": [
+          {
+            "doseAndRate": [
+              {
+                "doseQuantity": {
+                  "value": 1
+                }
+              }
+            ],
+            "timing": {
+              "repeat": {
+                "frequency": 2,
+                "period": 1,
+                "periodUnit": "d"
+              }
+            }
+          }
+        ],
+        "dispenseRequest": {
+          "expectedSupplyDuration": {
+            "code": "d",
+            "system": "http://unitsofmeasure.org",
+            "unit": "days",
+            "value": 30
+          },
+          "extension": [
+            {
+              "url": "http://cosri.org/fhir/pharmacy_name",
+              "valueString": "Corner Drugstore, Kirkland"
+            },
+            {
+              "url": "http://cosri.org/fhir/last_fill",
+              "valueDate": "2020-11-20"
+            }
+          ],
+          "quantity": {
+            "value": 60
+          }
+        },
+        "identifier": [
+          {
+            "system": "https://github.com/uwcirg/script-fhir-facade/"
+          }
+        ],
         "medicationCodeableConcept": {
           "coding": [
             {
-              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-              "code": "1049717",
-              "display": "Oxycodone Hydrochloride 10 MG Oral Capsule"
+              "code": "00591024110",
+              "display": "LORAZEPAM 1 MG TABLET",
+              "system": "http://hl7.org/fhir/sid/ndc"
+            },
+            {
+              "code": "197901",
+              "display": "LORAZEPAM 1 MG TABLET",
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm"
             }
           ],
-          "text": "Oxycodone Hydrochloride 10 MG Oral Capsule"
+          "text": "LORAZEPAM 1 MG TABLET"
         },
-        "authoredOn": "2017-07-15T16:01:00.000Z"
+        "requester": {
+          "display": "Joe Prescriber"
+        },
+        "resourceType": "MedicationRequest"
       }
     },
     {
@@ -1929,26 +1610,6 @@
           ],
           "text": "Buprenorphine 8 MG / Naloxone 2 MG Sublingual Tablet"
         },
-        "dosageInstruction": [
-          {
-            "timing": {
-              "repeat": {
-                "frequency": 1,
-                "period": 3.0,
-                "periodUnit": "d"
-              }
-            },
-            "asNeededBoolean": false,
-            "doseAndRate": [{
-              "doseQuantity": {
-                "value": 1.0,
-                "system": "http://unitsofmeasure.org",
-                "code": "mg",
-                "unit": "mg"
-              }
-            }]
-          }
-        ],
         "authoredOn": "2019-01-15T16:00:00.000Z"
       }
     },

--- a/src/utils/r4_test_patients/padme_amidfla.json
+++ b/src/utils/r4_test_patients/padme_amidfla.json
@@ -708,17 +708,69 @@
         "status": "active",
         "intent": "order",
         "doNotPerform": false,
+        "dispenseRequest": {
+          "expectedSupplyDuration": {
+            "code": "d",
+            "system": "http://unitsofmeasure.org",
+            "unit": "days",
+            "value": 1
+          },
+          "extension": [
+            {
+              "url": "http://cosri.org/fhir/pharmacy_name",
+              "valueString": "TEST, DOCTOR"
+            },
+            {
+              "url": "http://cosri.org/fhir/last_fill",
+              "valueDate": "2019-11-15"
+            }
+          ],
+          "quantity": {
+            "value": 1
+          }
+        },
+        "dosageInstruction": [
+          {
+            "doseAndRate": [
+              {
+                "doseQuantity": {
+                  "value": 1
+                }
+              }
+            ],
+            "timing": {
+              "repeat": {
+                "frequency": 1,
+                "period": 1,
+                "periodUnit": "d"
+              }
+            }
+          }
+        ],
+        "identifier": [
+          {
+            "system": "https://github.com/uwcirg/script-fhir-facade/"
+          }
+        ],
         "medicationCodeableConcept": {
           "coding": [
             {
-              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-              "code": "1049593",
-              "display": "12 HR Oxycodone Hydrochloride 60 MG Extended Release Oral Tablet"
+              "code": "00406577101",
+              "display": "METHADONE HCL 10 MG TABLET",
+              "system": "http://hl7.org/fhir/sid/ndc"
+            },
+            {
+              "code": "864706",
+              "display": "METHADONE HCL 10 MG TABLET",
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm"
             }
           ],
-          "text": "12 HR Oxycodone Hydrochloride 60 MG Extended Release Oral Tablet"
+          "text": "METHADONE HCL 10 MG TABLET"
         },
-        "authoredOn": "2019-04-15T16:02:00.000Z"
+        "requester": {
+          "display": "TEST TEST"
+        },
+        "authoredOn": "2019-11-15"
       }
     },
     {
@@ -731,17 +783,69 @@
         "status": "active",
         "intent": "order",
         "doNotPerform": false,
+        "dispenseRequest": {
+          "expectedSupplyDuration": {
+            "code": "d",
+            "system": "http://unitsofmeasure.org",
+            "unit": "days",
+            "value": 1
+          },
+          "extension": [
+            {
+              "url": "http://cosri.org/fhir/pharmacy_name",
+              "valueString": "TEST, DOCTOR"
+            },
+            {
+              "url": "http://cosri.org/fhir/last_fill",
+              "valueDate": "2019-11-01"
+            }
+          ],
+          "quantity": {
+            "value": 1
+          }
+        },
+        "dosageInstruction": [
+          {
+            "doseAndRate": [
+              {
+                "doseQuantity": {
+                  "value": 1
+                }
+              }
+            ],
+            "timing": {
+              "repeat": {
+                "frequency": 1,
+                "period": 1,
+                "periodUnit": "d"
+              }
+            }
+          }
+        ],
+        "identifier": [
+          {
+            "system": "https://github.com/uwcirg/script-fhir-facade/"
+          }
+        ],
         "medicationCodeableConcept": {
           "coding": [
             {
-              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-              "code": "1049593",
-              "display": "12 HR Oxycodone Hydrochloride 60 MG Extended Release Oral Tablet"
+              "code": "00406577101",
+              "display": "METHADONE HCL 10 MG TABLET",
+              "system": "http://hl7.org/fhir/sid/ndc"
+            },
+            {
+              "code": "864706",
+              "display": "METHADONE HCL 10 MG TABLET",
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm"
             }
           ],
-          "text": "12 HR Oxycodone Hydrochloride 60 MG Extended Release Oral Tablet"
+          "text": "METHADONE HCL 10 MG TABLET"
         },
-        "authoredOn": "2019-01-15T16:02:00.000Z"
+        "requester": {
+          "display": "TEST TEST"
+        },
+        "authoredOn": "2019-11-01"
       }
     },
     {
@@ -754,17 +858,69 @@
         "status": "active",
         "intent": "order",
         "doNotPerform": false,
+        "dispenseRequest": {
+          "expectedSupplyDuration": {
+            "code": "d",
+            "system": "http://unitsofmeasure.org",
+            "unit": "days",
+            "value": 1
+          },
+          "extension": [
+            {
+              "url": "http://cosri.org/fhir/pharmacy_name",
+              "valueString": "TEST, DOCTOR"
+            },
+            {
+              "url": "http://cosri.org/fhir/last_fill",
+              "valueDate": "2019-10-15"
+            }
+          ],
+          "quantity": {
+            "value": 1
+          }
+        },
+        "dosageInstruction": [
+          {
+            "doseAndRate": [
+              {
+                "doseQuantity": {
+                  "value": 1
+                }
+              }
+            ],
+            "timing": {
+              "repeat": {
+                "frequency": 1,
+                "period": 1,
+                "periodUnit": "d"
+              }
+            }
+          }
+        ],
+        "identifier": [
+          {
+            "system": "https://github.com/uwcirg/script-fhir-facade/"
+          }
+        ],
         "medicationCodeableConcept": {
           "coding": [
             {
-              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-              "code": "1049593",
-              "display": "12 HR Oxycodone Hydrochloride 60 MG Extended Release Oral Tablet"
+              "code": "00406577101",
+              "display": "METHADONE HCL 10 MG TABLET",
+              "system": "http://hl7.org/fhir/sid/ndc"
+            },
+            {
+              "code": "864706",
+              "display": "METHADONE HCL 10 MG TABLET",
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm"
             }
           ],
-          "text": "12 HR Oxycodone Hydrochloride 60 MG Extended Release Oral Tablet"
+          "text": "METHADONE HCL 10 MG TABLET"
         },
-        "authoredOn": "2018-10-15T16:02:00.000Z"
+        "requester": {
+          "display": "TEST TEST"
+        },
+        "authoredOn": "2019-10-15"
       }
     },
     {


### PR DESCRIPTION
Fix MME Graph to correctly render MME data points for medications containing overlapping prescription period.

Changes include:

- Fix graph processing logic to add daily MME values that occurred on the same date
- Fix CQL logic to not sum up MME values occurring on the same date. It show now only report daily MME value as is.
- Add Duration column to the PDMP Medications section
- Fix Development Tool display to remove non-CQL data results from CQL Results, placing them in the Other section
- update test patient jsons to include some examples from mock xml for testing
[Preview](https://launch.smarthealthit.org/launcher?launch_uri=https%3A%2F%2Fdeploy-preview-73--distracted-jepsen-bc9c39.netlify.com%2Flaunch.html&patient=5c41cecf-cf81-434f-9da7-e24e5a99dbc2&fhir_ver=4)