### PR TITLE
Mme calculator defaults updates

### DIFF
--- a/src/cql/r4/Factors_to_Consider_in_Managing_Chronic_Pain_FHIRv400.cql
+++ b/src/cql/r4/Factors_to_Consider_in_Managing_Chronic_Pain_FHIRv400.cql
@@ -364,7 +364,6 @@ define Is130orYounger:
   AgeInYears() <= 130
 
 // Determines if the patient meets the inclusion criteria for the CDS. Inclusion criteria is:
-// Age <= 100
 define MeetsInclusionCriteria:
   //Is18orOlder
   //fix this to allow people of all ages

--- a/src/cql/r4/Factors_to_Consider_in_Managing_Chronic_Pain_FHIRv400.cql
+++ b/src/cql/r4/Factors_to_Consider_in_Managing_Chronic_Pain_FHIRv400.cql
@@ -364,7 +364,7 @@ define Is130orYounger:
   AgeInYears() <= 130
 
 // Determines if the patient meets the inclusion criteria for the CDS. Inclusion criteria is:
-// - Age >=18 years
+// Age <= 100
 define MeetsInclusionCriteria:
   //Is18orOlder
   //fix this to allow people of all ages
@@ -671,6 +671,10 @@ define ReportPDMPMedicationRequests:
       End: ToString(CalculatedEnd), //of string type
       Quantity: GetMedicationRequestDispensedQuantity(O),
       Duration: if dispenseRequest.expectedSupplyDuration is not null then dispenseRequest.expectedSupplyDuration.value.value else null,
+      doseQuantity: MME_Object[0].doseQuantity,
+      dosesPerDay: MME_Object[0].dosesPerDay,
+      strength: MME_Object[0].strength,
+      factor: MME_Object[0].conversionFactor,
       MME: MME_Object[0].mme.value,
       Prescriber: O.requester.display.value,
       Pharmacy: GetMedicationRequestPharmacy(O),

--- a/src/cql/r4/Factors_to_Consider_in_Managing_Chronic_Pain_FHIRv400.json
+++ b/src/cql/r4/Factors_to_Consider_in_Managing_Chronic_Pain_FHIRv400.json
@@ -4467,6 +4467,74 @@
                            }
                         }
                      }, {
+                        "name" : "doseQuantity",
+                        "value" : {
+                           "path" : "doseQuantity",
+                           "type" : "Property",
+                           "source" : {
+                              "type" : "Indexer",
+                              "operand" : [ {
+                                 "name" : "MME_Object",
+                                 "type" : "QueryLetRef"
+                              }, {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "0",
+                                 "type" : "Literal"
+                              } ]
+                           }
+                        }
+                     }, {
+                        "name" : "dosesPerDay",
+                        "value" : {
+                           "path" : "dosesPerDay",
+                           "type" : "Property",
+                           "source" : {
+                              "type" : "Indexer",
+                              "operand" : [ {
+                                 "name" : "MME_Object",
+                                 "type" : "QueryLetRef"
+                              }, {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "0",
+                                 "type" : "Literal"
+                              } ]
+                           }
+                        }
+                     }, {
+                        "name" : "strength",
+                        "value" : {
+                           "path" : "strength",
+                           "type" : "Property",
+                           "source" : {
+                              "type" : "Indexer",
+                              "operand" : [ {
+                                 "name" : "MME_Object",
+                                 "type" : "QueryLetRef"
+                              }, {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "0",
+                                 "type" : "Literal"
+                              } ]
+                           }
+                        }
+                     }, {
+                        "name" : "factor",
+                        "value" : {
+                           "path" : "conversionFactor",
+                           "type" : "Property",
+                           "source" : {
+                              "type" : "Indexer",
+                              "operand" : [ {
+                                 "name" : "MME_Object",
+                                 "type" : "QueryLetRef"
+                              }, {
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "0",
+                                 "type" : "Literal"
+                              } ]
+                           }
+                        }
+                     }, {
                         "name" : "MME",
                         "value" : {
                            "path" : "value",
@@ -8181,4 +8249,3 @@
       }
    }
 }
-

--- a/src/cql/r4/MMECalculator.cql
+++ b/src/cql/r4/MMECalculator.cql
@@ -66,14 +66,6 @@ define function GetMedicationQuantity(medication MedicationRequest):
       ingredient: OMTKLogic.GetIngredients(rxNormCode),
       prescription: if ingredient is not null then First(ingredient) else null,
       dosageInstruction: O.dosageInstruction[0],
-      dispenseRequest: O.dispenseRequest,
-      supplyDuration: if dispenseRequest.expectedSupplyDuration is not null then System.Quantity {
-        value: dispenseRequest.expectedSupplyDuration.value,
-        unit: dispenseRequest.expectedSupplyDuration.unit
-      } else null as System.Quantity,
-      dispenseRequestQuantity: dispenseRequest.quantity.value.value,
-      //get dose quantity daily
-      dispenseRequestDoseQuantity: if supplyDuration is not null then dispenseRequestQuantity / supplyDuration.value else null as System.Quantity,
       doseAndRate:  if dosageInstruction is not null then dosageInstruction.doseAndRate[0] else null, //either a single doseRange or doseQuantity see specs here:  https://www.hl7.org/fhir/dosage-definitions.html#Dosage.doseAndRate.dose_x_
       dosage: if doseAndRate is not null then doseAndRate.dose else null,
       doseRange: if dosage is not null then ToFHIRRange(dosage) else null as Range,
@@ -88,8 +80,13 @@ define function GetMedicationQuantity(medication MedicationRequest):
                       value: dosage.value.value,
                       unit: doseUnit
                   }
-                when dispenseRequestDoseQuantity is not null then dispenseRequestDoseQuantity
-                else null as System.Quantity
+                //see FHIR dose definition:  https://www.hl7.org/fhir/dosage-definitions.html#Dosage.doseAndRate.dose_x_
+                //expect minium value of 0 to maximum value of 1
+                //example: if one wants to communicate that a tablet was 375 mg, the dose would be one tablet
+                else System.Quantity {
+                  value: 1.0,
+                  unit: doseUnit
+                }
               end
       return  case
                 when doseRange is not null and doseRange.high is not null then ToQuantity(doseRange.high)
@@ -114,11 +111,18 @@ define function Prescriptions(Orders List<MedicationRequest>):
       repeat: dosageInstruction.timing.repeat,
       frequency: Coalesce(repeat.frequencyMax.value, repeat.frequency.value),
       dispenseRequest: O.dispenseRequest,
+      supplyDuration: if dispenseRequest.expectedSupplyDuration is not null then System.Quantity {
+        value: dispenseRequest.expectedSupplyDuration.value,
+        unit: dispenseRequest.expectedSupplyDuration.unit
+      } else null as System.Quantity,
+      dispenseRequestQuantity: dispenseRequest.quantity.value.value,
       periodDuration: if repeat.period is not null then
         repeat.period.value else null,
       period: OMTKLogic.Quantity(periodDuration, repeat.periodUnit.value),
       doseRange: ToFHIRRange(doseAndRate.dose),
       doseQuantity: if doseAndRate.dose is not null then ToFHIRQuantity(doseAndRate.dose) else null as Quantity,
+      supplyQuantity: dispenseRequest.quantity.value.value,
+      supplyDuration: dispenseRequest.expectedSupplyDuration.value.value,
       doseDescription:
         Coalesce(
           // There should be a conversion from FHIR.SimpleQuantity to System.Quantity
@@ -150,10 +154,18 @@ define function Prescriptions(Orders List<MedicationRequest>):
       dose: GetMedicationQuantity(O),
       doseRange: doseRange,
       doseQuantity: doseAndRate.dose,
-      dosesPerDay: Coalesce(OMTKLogic.ToDaily(frequency, period), 1.0),
+      dosesPerDay:
+        if frequency is not null and period is not null then
+          Coalesce(OMTKLogic.ToDaily(frequency, period), 1.0)
+        else
+          //see CDC explanation of how doses per day is determine: https://www.cdc.gov/drugoverdose/training/dosing/accessible/index.html
+          if supplyDuration is not null and supplyQuantity is not null then
+            (supplyQuantity / supplyDuration)
+          else
+            null,
       strength: prescription.strength,
-      supplyQuantity: dispenseRequest.quantity.value.value,
-      supplyDuration: dispenseRequest.expectedSupplyDuration.value.value
+      supplyQuantity: supplyQuantity,
+      supplyDuration: supplyDuration
     }
 
 /*

--- a/src/cql/r4/MMECalculator.cql
+++ b/src/cql/r4/MMECalculator.cql
@@ -165,7 +165,7 @@ define function Prescriptions(Orders List<MedicationRequest>):
           Coalesce(OMTKLogic.ToDaily(frequency, period), 1.0)
         else
           //see CDC explanation of how doses per day is determine: https://www.cdc.gov/drugoverdose/training/dosing/accessible/index.html
-          if supplyDuration is not null and supplyQuantity is not null then
+          if supplyDuration != 0 and supplyDuration is not null and supplyQuantity is not null then
             (supplyQuantity / supplyDuration)
           else
             null,

--- a/src/cql/r4/MMECalculator.cql
+++ b/src/cql/r4/MMECalculator.cql
@@ -5,6 +5,12 @@ This library contains logic to surface the MME calculation functionality provide
 by the OMTKLogic library by extracting appropriate information from FHIR R4
 MedicationRequest resource.
 */
+/*
+ CHANGE LOG
+ 08/06/2021
+    provide 1.0 as the default dose quantity if doseQuantity is missing from Medication Request
+    provide (supplyQuantity / supplyDuration) calculation as default doses per day if frequency & period is missing from Medication Request
+*/
 
 using FHIR version '4.0.0'
 

--- a/src/cql/r4/MMECalculator.cql
+++ b/src/cql/r4/MMECalculator.cql
@@ -87,7 +87,7 @@ define function GetMedicationQuantity(medication MedicationRequest):
                       unit: doseUnit
                   }
                 //see FHIR dose definition:  https://www.hl7.org/fhir/dosage-definitions.html#Dosage.doseAndRate.dose_x_
-                //expect minium value of 0 to maximum value of 1
+                //expect minimum value of 0 to maximum value of 1
                 //example: if one wants to communicate that a tablet was 375 mg, the dose would be one tablet
                 else System.Quantity {
                   value: 1.0,

--- a/src/cql/r4/MMECalculator.json
+++ b/src/cql/r4/MMECalculator.json
@@ -413,155 +413,6 @@
                      } ]
                   }
                }, {
-                  "identifier" : "dispenseRequest",
-                  "expression" : {
-                     "path" : "dispenseRequest",
-                     "scope" : "O",
-                     "type" : "Property"
-                  }
-               }, {
-                  "identifier" : "supplyDuration",
-                  "expression" : {
-                     "type" : "If",
-                     "condition" : {
-                        "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
-                        "type" : "As",
-                        "operand" : {
-                           "type" : "Not",
-                           "operand" : {
-                              "type" : "IsNull",
-                              "operand" : {
-                                 "path" : "expectedSupplyDuration",
-                                 "type" : "Property",
-                                 "source" : {
-                                    "name" : "dispenseRequest",
-                                    "type" : "QueryLetRef"
-                                 }
-                              }
-                           }
-                        }
-                     },
-                     "then" : {
-                        "classType" : "{urn:hl7-org:elm-types:r1}Quantity",
-                        "type" : "Instance",
-                        "element" : [ {
-                           "name" : "value",
-                           "value" : {
-                              "name" : "ToDecimal",
-                              "libraryName" : "FHIRHelpers",
-                              "type" : "FunctionRef",
-                              "operand" : [ {
-                                 "path" : "value",
-                                 "type" : "Property",
-                                 "source" : {
-                                    "path" : "expectedSupplyDuration",
-                                    "type" : "Property",
-                                    "source" : {
-                                       "name" : "dispenseRequest",
-                                       "type" : "QueryLetRef"
-                                    }
-                                 }
-                              } ]
-                           }
-                        }, {
-                           "name" : "unit",
-                           "value" : {
-                              "name" : "ToString",
-                              "libraryName" : "FHIRHelpers",
-                              "type" : "FunctionRef",
-                              "operand" : [ {
-                                 "path" : "unit",
-                                 "type" : "Property",
-                                 "source" : {
-                                    "path" : "expectedSupplyDuration",
-                                    "type" : "Property",
-                                    "source" : {
-                                       "name" : "dispenseRequest",
-                                       "type" : "QueryLetRef"
-                                    }
-                                 }
-                              } ]
-                           }
-                        } ]
-                     },
-                     "else" : {
-                        "strict" : false,
-                        "type" : "As",
-                        "operand" : {
-                           "type" : "Null"
-                        },
-                        "asTypeSpecifier" : {
-                           "name" : "{urn:hl7-org:elm-types:r1}Quantity",
-                           "type" : "NamedTypeSpecifier"
-                        }
-                     }
-                  }
-               }, {
-                  "identifier" : "dispenseRequestQuantity",
-                  "expression" : {
-                     "path" : "value",
-                     "type" : "Property",
-                     "source" : {
-                        "path" : "value",
-                        "type" : "Property",
-                        "source" : {
-                           "path" : "quantity",
-                           "type" : "Property",
-                           "source" : {
-                              "name" : "dispenseRequest",
-                              "type" : "QueryLetRef"
-                           }
-                        }
-                     }
-                  }
-               }, {
-                  "identifier" : "dispenseRequestDoseQuantity",
-                  "expression" : {
-                     "type" : "If",
-                     "condition" : {
-                        "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
-                        "type" : "As",
-                        "operand" : {
-                           "type" : "Not",
-                           "operand" : {
-                              "type" : "IsNull",
-                              "operand" : {
-                                 "name" : "supplyDuration",
-                                 "type" : "QueryLetRef"
-                              }
-                           }
-                        }
-                     },
-                     "then" : {
-                        "type" : "ToQuantity",
-                        "operand" : {
-                           "type" : "Divide",
-                           "operand" : [ {
-                              "name" : "dispenseRequestQuantity",
-                              "type" : "QueryLetRef"
-                           }, {
-                              "path" : "value",
-                              "type" : "Property",
-                              "source" : {
-                                 "name" : "supplyDuration",
-                                 "type" : "QueryLetRef"
-                              }
-                           } ]
-                        }
-                     },
-                     "else" : {
-                        "strict" : false,
-                        "type" : "As",
-                        "operand" : {
-                           "type" : "Null"
-                        },
-                        "asTypeSpecifier" : {
-                           "name" : "{urn:hl7-org:elm-types:r1}Quantity",
-                           "type" : "NamedTypeSpecifier"
-                        }
-                     }
-                  }
-               }, {
                   "identifier" : "doseAndRate",
                   "expression" : {
                      "type" : "If",
@@ -819,32 +670,24 @@
                               }
                            } ]
                         }
-                     }, {
-                        "when" : {
-                           "type" : "Not",
-                           "operand" : {
-                              "type" : "IsNull",
-                              "operand" : {
-                                 "name" : "dispenseRequestDoseQuantity",
-                                 "type" : "QueryLetRef"
-                              }
-                           }
-                        },
-                        "then" : {
-                           "name" : "dispenseRequestDoseQuantity",
-                           "type" : "QueryLetRef"
-                        }
                      } ],
                      "else" : {
-                        "strict" : false,
-                        "type" : "As",
-                        "operand" : {
-                           "type" : "Null"
-                        },
-                        "asTypeSpecifier" : {
-                           "name" : "{urn:hl7-org:elm-types:r1}Quantity",
-                           "type" : "NamedTypeSpecifier"
-                        }
+                        "classType" : "{urn:hl7-org:elm-types:r1}Quantity",
+                        "type" : "Instance",
+                        "element" : [ {
+                           "name" : "value",
+                           "value" : {
+                              "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                              "value" : "1.0",
+                              "type" : "Literal"
+                           }
+                        }, {
+                           "name" : "unit",
+                           "value" : {
+                              "name" : "doseUnit",
+                              "type" : "QueryLetRef"
+                           }
+                        } ]
                      }
                   }
                } ],
@@ -1066,6 +909,101 @@
                      "type" : "Property"
                   }
                }, {
+                  "identifier" : "supplyDuration",
+                  "expression" : {
+                     "type" : "If",
+                     "condition" : {
+                        "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                        "type" : "As",
+                        "operand" : {
+                           "type" : "Not",
+                           "operand" : {
+                              "type" : "IsNull",
+                              "operand" : {
+                                 "path" : "expectedSupplyDuration",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "name" : "dispenseRequest",
+                                    "type" : "QueryLetRef"
+                                 }
+                              }
+                           }
+                        }
+                     },
+                     "then" : {
+                        "classType" : "{urn:hl7-org:elm-types:r1}Quantity",
+                        "type" : "Instance",
+                        "element" : [ {
+                           "name" : "value",
+                           "value" : {
+                              "name" : "ToDecimal",
+                              "libraryName" : "FHIRHelpers",
+                              "type" : "FunctionRef",
+                              "operand" : [ {
+                                 "path" : "value",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "path" : "expectedSupplyDuration",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "dispenseRequest",
+                                       "type" : "QueryLetRef"
+                                    }
+                                 }
+                              } ]
+                           }
+                        }, {
+                           "name" : "unit",
+                           "value" : {
+                              "name" : "ToString",
+                              "libraryName" : "FHIRHelpers",
+                              "type" : "FunctionRef",
+                              "operand" : [ {
+                                 "path" : "unit",
+                                 "type" : "Property",
+                                 "source" : {
+                                    "path" : "expectedSupplyDuration",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "dispenseRequest",
+                                       "type" : "QueryLetRef"
+                                    }
+                                 }
+                              } ]
+                           }
+                        } ]
+                     },
+                     "else" : {
+                        "strict" : false,
+                        "type" : "As",
+                        "operand" : {
+                           "type" : "Null"
+                        },
+                        "asTypeSpecifier" : {
+                           "name" : "{urn:hl7-org:elm-types:r1}Quantity",
+                           "type" : "NamedTypeSpecifier"
+                        }
+                     }
+                  }
+               }, {
+                  "identifier" : "dispenseRequestQuantity",
+                  "expression" : {
+                     "path" : "value",
+                     "type" : "Property",
+                     "source" : {
+                        "path" : "value",
+                        "type" : "Property",
+                        "source" : {
+                           "path" : "quantity",
+                           "type" : "Property",
+                           "source" : {
+                              "name" : "dispenseRequest",
+                              "type" : "QueryLetRef"
+                           }
+                        }
+                     }
+                  }
+               }, {
                   "identifier" : "periodDuration",
                   "expression" : {
                      "type" : "If",
@@ -1194,6 +1132,42 @@
                         "asTypeSpecifier" : {
                            "name" : "{http://hl7.org/fhir}Quantity",
                            "type" : "NamedTypeSpecifier"
+                        }
+                     }
+                  }
+               }, {
+                  "identifier" : "supplyQuantity",
+                  "expression" : {
+                     "path" : "value",
+                     "type" : "Property",
+                     "source" : {
+                        "path" : "value",
+                        "type" : "Property",
+                        "source" : {
+                           "path" : "quantity",
+                           "type" : "Property",
+                           "source" : {
+                              "name" : "dispenseRequest",
+                              "type" : "QueryLetRef"
+                           }
+                        }
+                     }
+                  }
+               }, {
+                  "identifier" : "supplyDuration",
+                  "expression" : {
+                     "path" : "value",
+                     "type" : "Property",
+                     "source" : {
+                        "path" : "value",
+                        "type" : "Property",
+                        "source" : {
+                           "path" : "expectedSupplyDuration",
+                           "type" : "Property",
+                           "source" : {
+                              "name" : "dispenseRequest",
+                              "type" : "QueryLetRef"
+                           }
                         }
                      }
                   }
@@ -1542,23 +1516,98 @@
                      }, {
                         "name" : "dosesPerDay",
                         "value" : {
-                           "type" : "Coalesce",
-                           "operand" : [ {
-                              "name" : "ToDaily",
-                              "libraryName" : "OMTKLogic",
-                              "type" : "FunctionRef",
+                           "type" : "If",
+                           "condition" : {
+                              "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                              "type" : "As",
+                              "operand" : {
+                                 "type" : "And",
+                                 "operand" : [ {
+                                    "type" : "Not",
+                                    "operand" : {
+                                       "type" : "IsNull",
+                                       "operand" : {
+                                          "name" : "frequency",
+                                          "type" : "QueryLetRef"
+                                       }
+                                    }
+                                 }, {
+                                    "type" : "Not",
+                                    "operand" : {
+                                       "type" : "IsNull",
+                                       "operand" : {
+                                          "name" : "period",
+                                          "type" : "QueryLetRef"
+                                       }
+                                    }
+                                 } ]
+                              }
+                           },
+                           "then" : {
+                              "type" : "Coalesce",
                               "operand" : [ {
-                                 "name" : "frequency",
-                                 "type" : "QueryLetRef"
+                                 "name" : "ToDaily",
+                                 "libraryName" : "OMTKLogic",
+                                 "type" : "FunctionRef",
+                                 "operand" : [ {
+                                    "name" : "frequency",
+                                    "type" : "QueryLetRef"
+                                 }, {
+                                    "name" : "period",
+                                    "type" : "QueryLetRef"
+                                 } ]
                               }, {
-                                 "name" : "period",
-                                 "type" : "QueryLetRef"
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                 "value" : "1.0",
+                                 "type" : "Literal"
                               } ]
-                           }, {
-                              "valueType" : "{urn:hl7-org:elm-types:r1}Decimal",
-                              "value" : "1.0",
-                              "type" : "Literal"
-                           } ]
+                           },
+                           "else" : {
+                              "type" : "If",
+                              "condition" : {
+                                 "asType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                                 "type" : "As",
+                                 "operand" : {
+                                    "type" : "And",
+                                    "operand" : [ {
+                                       "type" : "Not",
+                                       "operand" : {
+                                          "type" : "IsNull",
+                                          "operand" : {
+                                             "name" : "supplyDuration",
+                                             "type" : "QueryLetRef"
+                                          }
+                                       }
+                                    }, {
+                                       "type" : "Not",
+                                       "operand" : {
+                                          "type" : "IsNull",
+                                          "operand" : {
+                                             "name" : "supplyQuantity",
+                                             "type" : "QueryLetRef"
+                                          }
+                                       }
+                                    } ]
+                                 }
+                              },
+                              "then" : {
+                                 "type" : "Divide",
+                                 "operand" : [ {
+                                    "name" : "supplyQuantity",
+                                    "type" : "QueryLetRef"
+                                 }, {
+                                    "name" : "supplyDuration",
+                                    "type" : "QueryLetRef"
+                                 } ]
+                              },
+                              "else" : {
+                                 "asType" : "{urn:hl7-org:elm-types:r1}Decimal",
+                                 "type" : "As",
+                                 "operand" : {
+                                    "type" : "Null"
+                                 }
+                              }
+                           }
                         }
                      }, {
                         "name" : "strength",
@@ -1599,38 +1648,14 @@
                      }, {
                         "name" : "supplyQuantity",
                         "value" : {
-                           "path" : "value",
-                           "type" : "Property",
-                           "source" : {
-                              "path" : "value",
-                              "type" : "Property",
-                              "source" : {
-                                 "path" : "quantity",
-                                 "type" : "Property",
-                                 "source" : {
-                                    "name" : "dispenseRequest",
-                                    "type" : "QueryLetRef"
-                                 }
-                              }
-                           }
+                           "name" : "supplyQuantity",
+                           "type" : "QueryLetRef"
                         }
                      }, {
                         "name" : "supplyDuration",
                         "value" : {
-                           "path" : "value",
-                           "type" : "Property",
-                           "source" : {
-                              "path" : "value",
-                              "type" : "Property",
-                              "source" : {
-                                 "path" : "expectedSupplyDuration",
-                                 "type" : "Property",
-                                 "source" : {
-                                    "name" : "dispenseRequest",
-                                    "type" : "QueryLetRef"
-                                 }
-                              }
-                           }
+                           "name" : "supplyDuration",
+                           "type" : "QueryLetRef"
                         }
                      } ]
                   }

--- a/src/cql/r4/MMECalculator.json
+++ b/src/cql/r4/MMECalculator.json
@@ -1570,14 +1570,33 @@
                                  "operand" : {
                                     "type" : "And",
                                     "operand" : [ {
-                                       "type" : "Not",
-                                       "operand" : {
-                                          "type" : "IsNull",
+                                       "type" : "And",
+                                       "operand" : [ {
+                                          "type" : "Not",
                                           "operand" : {
-                                             "name" : "supplyDuration",
-                                             "type" : "QueryLetRef"
+                                             "type" : "Equal",
+                                             "operand" : [ {
+                                                "name" : "supplyDuration",
+                                                "type" : "QueryLetRef"
+                                             }, {
+                                                "type" : "ToDecimal",
+                                                "operand" : {
+                                                   "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                                   "value" : "0",
+                                                   "type" : "Literal"
+                                                }
+                                             } ]
                                           }
-                                       }
+                                       }, {
+                                          "type" : "Not",
+                                          "operand" : {
+                                             "type" : "IsNull",
+                                             "operand" : {
+                                                "name" : "supplyDuration",
+                                                "type" : "QueryLetRef"
+                                             }
+                                          }
+                                       } ]
                                     }, {
                                        "type" : "Not",
                                        "operand" : {

--- a/src/cql/r4/OMTKLogic.cql
+++ b/src/cql/r4/OMTKLogic.cql
@@ -326,6 +326,7 @@ define function GetDailyDose(ingredientCode Code, strength Quantity, doseFormCod
     when ToInteger(doseFormCode.code) = 316987 then
       /* buprenorphine or fentanyl patch */
       if ToInteger(ingredientCode.code) in { 1819, 4337 } then
+       // Quantity { value: dosesPerDay * doseQuantity.value * strength.value, unit: strength.unit }
        /*
         * https://drive.google.com/drive/u/1/folders/1SQ7tufdYatX4qZeZtk6S5xWeNVC0zOQf
           The MME conversion factor for buprenorphine patches is based on the assumption that one milligram of parenteral buprenorphine is equivalent to 75 milligrams of oral morphine and that one patch delivers the dispensed micrograms per hour over a 24 hour day. Example: 5 ug/hr buprenorphine patch X 24 hrs = 120 ug/day buprenorphine = 0.12 mg/day = 9 mg/day oral MME. In other words, the conversion factor not accounting for days of use would be 9/5 or 1.8. However, since the buprenorphine patch remains in place for 7 days, we have multiplied the conversion factor by 7 (1.8 X 7 = 12.6). In this example, MME/day for four 5 μg/hr buprenorphine patches dispensed for use over 28 days would work out as follows: Example: 5 ug/hr buprenorphine patch X (4 patches/28 days) X 12.6 = 9 MME/day. Please note that because this allowance has been made based on the typical dosage of one buprenorphine patch per 7 days, you should first change all Days Supply in your prescription data to follow this standard, i.e., Days Supply for buprenorphine patches= # of patches x 7.

--- a/src/cql/r4/OMTKLogic.cql
+++ b/src/cql/r4/OMTKLogic.cql
@@ -318,7 +318,7 @@ define function StripPer(unit String):
 /*
   Calculates daily dose for a specific ingredient based on the ingredient strength, dose form, dose quantity, and daily frequency
 */
-define function GetDailyDose(ingredientCode Code, strength Quantity, doseFormCode Code, doseQuantity Quantity, dosesPerDay Decimal, supplyQuantity Decimal, supplyDuration Decimal):
+define function GetDailyDose(ingredientCode Code, strength Quantity, doseFormCode Code, doseQuantity Quantity, dosesPerDay Decimal):
   case
     when dosesPerDay is null or doseQuantity is null or strength is null then
       null as Quantity
@@ -326,7 +326,6 @@ define function GetDailyDose(ingredientCode Code, strength Quantity, doseFormCod
     when ToInteger(doseFormCode.code) = 316987 then
       /* buprenorphine or fentanyl patch */
       if ToInteger(ingredientCode.code) in { 1819, 4337 } then
-       // Quantity { value: dosesPerDay * doseQuantity.value * strength.value, unit: strength.unit }
        /*
         * https://drive.google.com/drive/u/1/folders/1SQ7tufdYatX4qZeZtk6S5xWeNVC0zOQf
           The MME conversion factor for buprenorphine patches is based on the assumption that one milligram of parenteral buprenorphine is equivalent to 75 milligrams of oral morphine and that one patch delivers the dispensed micrograms per hour over a 24 hour day. Example: 5 ug/hr buprenorphine patch X 24 hrs = 120 ug/day buprenorphine = 0.12 mg/day = 9 mg/day oral MME. In other words, the conversion factor not accounting for days of use would be 9/5 or 1.8. However, since the buprenorphine patch remains in place for 7 days, we have multiplied the conversion factor by 7 (1.8 X 7 = 12.6). In this example, MME/day for four 5 μg/hr buprenorphine patches dispensed for use over 28 days would work out as follows: Example: 5 ug/hr buprenorphine patch X (4 patches/28 days) X 12.6 = 9 MME/day. Please note that because this allowance has been made based on the typical dosage of one buprenorphine patch per 7 days, you should first change all Days Supply in your prescription data to follow this standard, i.e., Days Supply for buprenorphine patches= # of patches x 7.
@@ -340,7 +339,7 @@ define function GetDailyDose(ingredientCode Code, strength Quantity, doseFormCod
         data to follow this standard, i.e., Days Supply for fentanyl patches= # of patches X 3.
         */
         //1819 is buprenorphine, 4337 is fentanyl
-        Quantity { value: (supplyQuantity / supplyDuration) * strength.value, unit: strength.unit }
+        Quantity { value: dosesPerDay * strength.value, unit: strength.unit }
 
       else
         Message(null, true, 'OMTKLogic.GetDailyDoseDescription.UnknownPatchIngredient', ErrorLevel, 'Unknown patch ingredient: ' & ingredientCode.code & ':' & ingredientCode.display)
@@ -404,7 +403,7 @@ define function CalculateMMEs(medications List<Tuple { rxNormCode Code, doseQuan
         Ingredients I
           let
             adjustedDoseQuantity: EnsureMicrogramQuantity(M.doseQuantity),
-            dailyDose: GetDailyDose(I.ingredientCode, I.strength, I.doseFormCode, adjustedDoseQuantity, M.dosesPerDay, M.supplyQuantity, M.supplyDuration),
+            dailyDose: GetDailyDose(I.ingredientCode, I.strength, I.doseFormCode, adjustedDoseQuantity, M.dosesPerDay),
             dailyDoseDescription: GetDailyDoseDescription(I.ingredientCode, I.strength, I.doseFormCode, adjustedDoseQuantity, M.dosesPerDay, dailyDose, M.supplyQuantity, M.supplyDuration),
             factor: GetConversionFactor(I.ingredientCode, dailyDose, I.doseFormCode)
           return {

--- a/src/cql/r4/OMTKLogic.json
+++ b/src/cql/r4/OMTKLogic.json
@@ -3121,14 +3121,8 @@
                            "value" : {
                               "type" : "Multiply",
                               "operand" : [ {
-                                 "type" : "Divide",
-                                 "operand" : [ {
-                                    "name" : "supplyQuantity",
-                                    "type" : "OperandRef"
-                                 }, {
-                                    "name" : "supplyDuration",
-                                    "type" : "OperandRef"
-                                 } ]
+                                 "name" : "dosesPerDay",
+                                 "type" : "OperandRef"
                               }, {
                                  "path" : "value",
                                  "type" : "Property",
@@ -3467,18 +3461,6 @@
                }
             }, {
                "name" : "dosesPerDay",
-               "operandTypeSpecifier" : {
-                  "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                  "type" : "NamedTypeSpecifier"
-               }
-            }, {
-               "name" : "supplyQuantity",
-               "operandTypeSpecifier" : {
-                  "name" : "{urn:hl7-org:elm-types:r1}Decimal",
-                  "type" : "NamedTypeSpecifier"
-               }
-            }, {
-               "name" : "supplyDuration",
                "operandTypeSpecifier" : {
                   "name" : "{urn:hl7-org:elm-types:r1}Decimal",
                   "type" : "NamedTypeSpecifier"
@@ -4209,14 +4191,6 @@
                                  "type" : "QueryLetRef"
                               }, {
                                  "path" : "dosesPerDay",
-                                 "scope" : "M",
-                                 "type" : "Property"
-                              }, {
-                                 "path" : "supplyQuantity",
-                                 "scope" : "M",
-                                 "type" : "Property"
-                              }, {
-                                 "path" : "supplyDuration",
                                  "scope" : "M",
                                  "type" : "Property"
                               } ]


### PR DESCRIPTION
Address: https://www.pivotaltracker.com/story/show/178935354
Provide default values for dose quantity and/or doses per day for MME calculator **if** they are missing from Medication Request JSON from the backend.  NOTE, these are fallback calculations.  Dose quantity information from a FHIR endpoint, e.g. confidential backend, will always be used first if present.
Changes include:

- provide default of doseQuantity of 1.0 (see [FHIR specs](https://www.hl7.org/fhir/dosage-definitions.html#Dosage.doseAndRate.dose_x_))
- provide default calculated daily dose, i.e. supplyQuantity / supplyDuration, if frequency and period is missing from the Medication Request JSON.

Current calculations done in confidential back can be seen [here](https://github.com/uwcirg/sof-api-wrapper/blob/e2add2dcbb78d4d273a2d10460d510e99491942c/sof_wrapper/api/fhir.py#L40)