### PR TITLE
fix underage warning message stylings

### DIFF
--- a/src/components/Warning.js
+++ b/src/components/Warning.js
@@ -26,12 +26,12 @@ export default class ExclusionBanner extends Component {
     const conditionalClass = this.state.displayed ? '': 'close';
     return (
       <div
-        className={`exclusion-banner banner addon-text ${conditionalClass}`}
+        className={`exclusion-banner banner addon-text warning ${conditionalClass}`}
         role="banner"
         onClick={this.handleCloseToggle}>
         <ChevronDownIcon className="close-button" icon="times" title="close"  width="25" height="25" />
 
-        <div className="exclusion-banner__description">
+        <div className="exclusion-banner__description warning">
           <strong className="title"><FontAwesomeIcon icon="exclamation-circle" title="notice" /> WARNING</strong> <span className="content">{this.props.text}</span>
         </div>
       </div>

--- a/src/styles/elements/_banners.scss
+++ b/src/styles/elements/_banners.scss
@@ -22,6 +22,9 @@
     text-align: left;
     background-color: $color-beige;
     position: relative;
+    &.warning {
+      background-color: $color-red-darker;
+    }
 
     &__tag {
       margin-bottom: 20px;
@@ -29,6 +32,11 @@
 
     strong {
       color: $color-orange;
+    }
+    &.warning {
+      strong {
+        color: #FFF;
+      }
     }
     .title {
       margin-right: 4px
@@ -41,10 +49,6 @@
       padding: 10px;
       font-weight: 600;
     }
-    &.addon-text {
-      margin-top: -16px;
-    }
-
     .close-button {
       position: absolute;
       right: 24px;
@@ -78,6 +82,10 @@
   .inclusion-banner {
     &__description {
       color: $color-black;
+      &.warning {
+        color: #FFF;
+        font-weight: 600;
+      }
     }
   }
 }


### PR DESCRIPTION
Address https://www.pivotaltracker.com/story/show/178887243
Update stylings for the warning message presented for underage patient 
Changes include:
change background color to red
bold the warning text