### PR TITLE
fix null conversion factor issue for methadone

### DIFF
--- a/src/cql/r4/OMTKLogic.cql
+++ b/src/cql/r4/OMTKLogic.cql
@@ -175,6 +175,9 @@ define function GetConversionFactor(ingredientCode Code, dailyDose Quantity, dos
       case
         /*
          * note Truncate will get integer part of the argument
+         * see conversion info here:
+         * https://drive.google.com/file/d/1AkPKoYWMOUPG4V8MbX57CH8tX60pOaOJ/view?usp=sharing
+         * https://www.cdc.gov/drugoverdose/pdf/calculating_total_daily_dose-a.pdf
          */
         when Truncate(dailyDose.value) between 1 and 20 then 4
         when Truncate(dailyDose.value) between 21 and 40 then 8

--- a/src/cql/r4/OMTKLogic.cql
+++ b/src/cql/r4/OMTKLogic.cql
@@ -34,6 +34,7 @@ Epub 2011 Apr 21. PubMed PMID: 21515544; PubMed Central PMCID: PMC3128404.
 * 09/13/21  Add conversion factors for oliceridine & benzhydrocodone; Update conversion factor to 0.3 for Meperidine IV form
 * 09/13/21 Update conversion factors for fentanyl injection, mucosal spray and lozenge product (1, 0.18, 0.13 respectively)
 * 09/13/21 Add conversion factor for benzhydrocodone
+* 09/21/21 BugFix fix integer/decimal daily dose comparison when detetermine conversion factor for Methodone
 */
 
 include OMTKData version '3.0.0' called OMTKData
@@ -172,10 +173,13 @@ define function GetConversionFactor(ingredientCode Code, dailyDose Quantity, dos
     )
     when 6813 then ( /*	Methadone */
       case
-        when dailyDose.value between 1 and 20 then 4
-        when dailyDose.value between 21 and 40 then 8
-        when dailyDose.value between 41 and 60 then 10
-        when dailyDose.value >= 61 then 12
+        /*
+         * note Truncate will get integer part of the argument
+         */
+        when Truncate(dailyDose.value) between 1 and 20 then 4
+        when Truncate(dailyDose.value) between 21 and 40 then 8
+        when Truncate(dailyDose.value) between 41 and 60 then 10
+        when Truncate(dailyDose.value) >= 61 then 12
         else Message(null, dailyDose.value < 1, 'OMTKLogic.GetConversionFactor.DailyDoseLessThanOne', ErrorLevel, 'Daily dose less than 1')
       end
     )

--- a/src/cql/r4/OMTKLogic.cql
+++ b/src/cql/r4/OMTKLogic.cql
@@ -174,7 +174,7 @@ define function GetConversionFactor(ingredientCode Code, dailyDose Quantity, dos
     when 6813 then ( /*	Methadone */
       case
         /*
-         * note Ceiling will the first integer greater than or equal to its argument
+         * note Ceiling will return the first integer greater than or equal to its argument
          * see conversion info here:
          * https://www.cdc.gov/drugoverdose/pdf/calculating_total_daily_dose-a.pdf
          */

--- a/src/cql/r4/OMTKLogic.cql
+++ b/src/cql/r4/OMTKLogic.cql
@@ -176,7 +176,6 @@ define function GetConversionFactor(ingredientCode Code, dailyDose Quantity, dos
         /*
          * note Truncate will get integer part of the argument
          * see conversion info here:
-         * https://drive.google.com/file/d/1AkPKoYWMOUPG4V8MbX57CH8tX60pOaOJ/view?usp=sharing
          * https://www.cdc.gov/drugoverdose/pdf/calculating_total_daily_dose-a.pdf
          */
         when Truncate(dailyDose.value) between 1 and 20 then 4

--- a/src/cql/r4/OMTKLogic.cql
+++ b/src/cql/r4/OMTKLogic.cql
@@ -174,14 +174,14 @@ define function GetConversionFactor(ingredientCode Code, dailyDose Quantity, dos
     when 6813 then ( /*	Methadone */
       case
         /*
-         * note Truncate will get integer part of the argument
+         * note Ceiling will the first integer greater than or equal to its argument
          * see conversion info here:
          * https://www.cdc.gov/drugoverdose/pdf/calculating_total_daily_dose-a.pdf
          */
-        when Truncate(dailyDose.value) between 1 and 20 then 4
-        when Truncate(dailyDose.value) between 21 and 40 then 8
-        when Truncate(dailyDose.value) between 41 and 60 then 10
-        when Truncate(dailyDose.value) >= 61 then 12
+        when Ceiling(dailyDose.value) between 1 and 20 then 4
+        when Ceiling(dailyDose.value) between 21 and 40 then 8
+        when Ceiling(dailyDose.value) between 41 and 60 then 10
+        when Ceiling(dailyDose.value) >= 61 then 12
         else Message(null, dailyDose.value < 1, 'OMTKLogic.GetConversionFactor.DailyDoseLessThanOne', ErrorLevel, 'Daily dose less than 1')
       end
     )

--- a/src/cql/r4/OMTKLogic.json
+++ b/src/cql/r4/OMTKLogic.json
@@ -1777,36 +1777,36 @@
                               "operand" : [ {
                                  "type" : "GreaterOrEqual",
                                  "operand" : [ {
-                                    "path" : "value",
-                                    "type" : "Property",
-                                    "source" : {
-                                       "name" : "dailyDose",
-                                       "type" : "OperandRef"
+                                    "type" : "Truncate",
+                                    "operand" : {
+                                       "path" : "value",
+                                       "type" : "Property",
+                                       "source" : {
+                                          "name" : "dailyDose",
+                                          "type" : "OperandRef"
+                                       }
                                     }
                                  }, {
-                                    "type" : "ToDecimal",
-                                    "operand" : {
-                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                       "value" : "1",
-                                       "type" : "Literal"
-                                    }
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "1",
+                                    "type" : "Literal"
                                  } ]
                               }, {
                                  "type" : "LessOrEqual",
                                  "operand" : [ {
-                                    "path" : "value",
-                                    "type" : "Property",
-                                    "source" : {
-                                       "name" : "dailyDose",
-                                       "type" : "OperandRef"
+                                    "type" : "Truncate",
+                                    "operand" : {
+                                       "path" : "value",
+                                       "type" : "Property",
+                                       "source" : {
+                                          "name" : "dailyDose",
+                                          "type" : "OperandRef"
+                                       }
                                     }
                                  }, {
-                                    "type" : "ToDecimal",
-                                    "operand" : {
-                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                       "value" : "20",
-                                       "type" : "Literal"
-                                    }
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "20",
+                                    "type" : "Literal"
                                  } ]
                               } ]
                            },
@@ -1821,36 +1821,36 @@
                               "operand" : [ {
                                  "type" : "GreaterOrEqual",
                                  "operand" : [ {
-                                    "path" : "value",
-                                    "type" : "Property",
-                                    "source" : {
-                                       "name" : "dailyDose",
-                                       "type" : "OperandRef"
+                                    "type" : "Truncate",
+                                    "operand" : {
+                                       "path" : "value",
+                                       "type" : "Property",
+                                       "source" : {
+                                          "name" : "dailyDose",
+                                          "type" : "OperandRef"
+                                       }
                                     }
                                  }, {
-                                    "type" : "ToDecimal",
-                                    "operand" : {
-                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                       "value" : "21",
-                                       "type" : "Literal"
-                                    }
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "21",
+                                    "type" : "Literal"
                                  } ]
                               }, {
                                  "type" : "LessOrEqual",
                                  "operand" : [ {
-                                    "path" : "value",
-                                    "type" : "Property",
-                                    "source" : {
-                                       "name" : "dailyDose",
-                                       "type" : "OperandRef"
+                                    "type" : "Truncate",
+                                    "operand" : {
+                                       "path" : "value",
+                                       "type" : "Property",
+                                       "source" : {
+                                          "name" : "dailyDose",
+                                          "type" : "OperandRef"
+                                       }
                                     }
                                  }, {
-                                    "type" : "ToDecimal",
-                                    "operand" : {
-                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                       "value" : "40",
-                                       "type" : "Literal"
-                                    }
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "40",
+                                    "type" : "Literal"
                                  } ]
                               } ]
                            },
@@ -1865,36 +1865,36 @@
                               "operand" : [ {
                                  "type" : "GreaterOrEqual",
                                  "operand" : [ {
-                                    "path" : "value",
-                                    "type" : "Property",
-                                    "source" : {
-                                       "name" : "dailyDose",
-                                       "type" : "OperandRef"
+                                    "type" : "Truncate",
+                                    "operand" : {
+                                       "path" : "value",
+                                       "type" : "Property",
+                                       "source" : {
+                                          "name" : "dailyDose",
+                                          "type" : "OperandRef"
+                                       }
                                     }
                                  }, {
-                                    "type" : "ToDecimal",
-                                    "operand" : {
-                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                       "value" : "41",
-                                       "type" : "Literal"
-                                    }
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "41",
+                                    "type" : "Literal"
                                  } ]
                               }, {
                                  "type" : "LessOrEqual",
                                  "operand" : [ {
-                                    "path" : "value",
-                                    "type" : "Property",
-                                    "source" : {
-                                       "name" : "dailyDose",
-                                       "type" : "OperandRef"
+                                    "type" : "Truncate",
+                                    "operand" : {
+                                       "path" : "value",
+                                       "type" : "Property",
+                                       "source" : {
+                                          "name" : "dailyDose",
+                                          "type" : "OperandRef"
+                                       }
                                     }
                                  }, {
-                                    "type" : "ToDecimal",
-                                    "operand" : {
-                                       "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                       "value" : "60",
-                                       "type" : "Literal"
-                                    }
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                    "value" : "60",
+                                    "type" : "Literal"
                                  } ]
                               } ]
                            },
@@ -1907,19 +1907,19 @@
                            "when" : {
                               "type" : "GreaterOrEqual",
                               "operand" : [ {
-                                 "path" : "value",
-                                 "type" : "Property",
-                                 "source" : {
-                                    "name" : "dailyDose",
-                                    "type" : "OperandRef"
+                                 "type" : "Truncate",
+                                 "operand" : {
+                                    "path" : "value",
+                                    "type" : "Property",
+                                    "source" : {
+                                       "name" : "dailyDose",
+                                       "type" : "OperandRef"
+                                    }
                                  }
                               }, {
-                                 "type" : "ToDecimal",
-                                 "operand" : {
-                                    "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
-                                    "value" : "61",
-                                    "type" : "Literal"
-                                 }
+                                 "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                                 "value" : "61",
+                                 "type" : "Literal"
                               } ]
                            },
                            "then" : {

--- a/src/cql/r4/OMTKLogic.json
+++ b/src/cql/r4/OMTKLogic.json
@@ -1777,7 +1777,7 @@
                               "operand" : [ {
                                  "type" : "GreaterOrEqual",
                                  "operand" : [ {
-                                    "type" : "Truncate",
+                                    "type" : "Ceiling",
                                     "operand" : {
                                        "path" : "value",
                                        "type" : "Property",
@@ -1794,7 +1794,7 @@
                               }, {
                                  "type" : "LessOrEqual",
                                  "operand" : [ {
-                                    "type" : "Truncate",
+                                    "type" : "Ceiling",
                                     "operand" : {
                                        "path" : "value",
                                        "type" : "Property",
@@ -1821,7 +1821,7 @@
                               "operand" : [ {
                                  "type" : "GreaterOrEqual",
                                  "operand" : [ {
-                                    "type" : "Truncate",
+                                    "type" : "Ceiling",
                                     "operand" : {
                                        "path" : "value",
                                        "type" : "Property",
@@ -1838,7 +1838,7 @@
                               }, {
                                  "type" : "LessOrEqual",
                                  "operand" : [ {
-                                    "type" : "Truncate",
+                                    "type" : "Ceiling",
                                     "operand" : {
                                        "path" : "value",
                                        "type" : "Property",
@@ -1865,7 +1865,7 @@
                               "operand" : [ {
                                  "type" : "GreaterOrEqual",
                                  "operand" : [ {
-                                    "type" : "Truncate",
+                                    "type" : "Ceiling",
                                     "operand" : {
                                        "path" : "value",
                                        "type" : "Property",
@@ -1882,7 +1882,7 @@
                               }, {
                                  "type" : "LessOrEqual",
                                  "operand" : [ {
-                                    "type" : "Truncate",
+                                    "type" : "Ceiling",
                                     "operand" : {
                                        "path" : "value",
                                        "type" : "Property",
@@ -1907,7 +1907,7 @@
                            "when" : {
                               "type" : "GreaterOrEqual",
                               "operand" : [ {
-                                 "type" : "Truncate",
+                                 "type" : "Ceiling",
                                  "operand" : {
                                     "path" : "value",
                                     "type" : "Property",


### PR DESCRIPTION
Address null conversion factor returned for methadone (ingredient code of  `6913`)
For methadone, conditional comparison of daily dose to determine conversion factor fails when daily dose **is not** integer (e.g. 4.0476190476190474)
Fix is to add operator, Ceiling, that will return the first integer greater than or equal to its argument, in the comparison

