### PR TITLE
update WA guideline text for benzo, sedatives, barbiturates and caripsoprodol

### DIFF
--- a/src/components/summary.json
+++ b/src/components/summary.json
@@ -740,6 +740,11 @@
             "type": "CDC",
             "title": "CDC Guideline #11",
             "text": "Avoid concurrent opioid and benzodiazepine prescribing."
+          },
+          {
+            "type": "WA",
+            "title": "WA AMDG Guideline",
+            "text": "Washington State rules require that co-prescribing of opioids and benzodiazepine medications requires documentation, discussion of risks, and consideration of tapering medications."
           }
         ],
         "info": [
@@ -812,8 +817,8 @@
         "guideline": [
           {
             "type": "WA",
-            "title": "WA Guideline",
-            "text": "Washington State Rules require documentation of decision making when coprescribing sedatives with opioids."
+            "title": "WA AMDG Guideline",
+            "text": "Washington State rules require that co-prescribing of opioids and sedatives requires documentation, discussion of risks, and consideration of tapering medications."
           }
         ],
         "info": [
@@ -885,8 +890,8 @@
         "guideline": [
           {
             "type": "WA",
-            "title": "WA Guideline",
-            "text": "Washington State Rules require documentation of decision making when coprescribing barbiturates with opioids."
+            "title": "WA AMDG Guideline",
+            "text": "Washington State rules require that co-prescribing of opioids and barbiturates requires documentation, discussion of risks, and consideration of tapering medications."
           }
         ],
         "info": [
@@ -958,8 +963,8 @@
         "guideline": [
           {
             "type": "WA",
-            "title": "WA Guideline",
-            "text": "Washington State Rules require documentation of decision making when coprescribing carisoprodol with opioids."
+            "title": "WA AMDG Guideline",
+            "text": "Washington State rules require that co-prescribing of opioids and carisoprodol medications requires documentation, discussion of risks, and consideration of tapering medications."
           }
         ],
         "info": [


### PR DESCRIPTION
Per feedback, update WA guideline text for benzodiazepine medications, sedatives, barbiturates and caripsoprodol medications
See https://drive.google.com/file/d/1uXTgGUAsiqI2MuZ9YS0CMf3OzL3KsIkF/view