### PR TITLE
redirect to patient search dashboard page when token is missing

### DIFF
--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -224,13 +224,13 @@ export default class Landing extends Component {
      * fetch env data where necessary, i.e. env.json, to ensure REACT env variables are available
      */
     fetchEnvData();
+    //start time out countdown on DOM mounted
+    Timeout();
     this.pingProcessProgress();
     let result = {};
     Promise.all([executeElm(this.state.collector)])
     .then(
       response => {
-        //start time out countdown
-        Timeout();
         //set result from data from EPIC
         let EPICData = response[0];
         result['Summary'] = EPICData ? {...EPICData['Summary']} : {};
@@ -863,7 +863,7 @@ export default class Landing extends Component {
 
     if (this.state.result == null) {
       return (
-        <div className="banner error">
+        <div className="banner error root-error">
           <div>
             <FontAwesomeIcon icon="exclamation-circle" title="error" /> Error: See console for details.
           </div>

--- a/src/helpers/timeout.js
+++ b/src/helpers/timeout.js
@@ -136,7 +136,8 @@ var Timeout = (function() {
   }
 
   function isDOMReady() {
-    var targetNode = document.querySelector(".landing");
+    //DOM root element, it could be an error element indicating null state
+    var targetNode = document.querySelector(".landing") || document.querySelector(".root-error");
     if (!targetNode) return false;
     clearInterval(waitForDOMIntervalId);
     return true;
@@ -184,6 +185,14 @@ var Timeout = (function() {
       });
     });
   }
+  function handleNoToken() {
+    getSessionTokenInfo();
+    if (!tokenInfo || !Object.keys(tokenInfo).length) {
+      //back to dashboard
+      window.location = getEnv("REACT_APP_DASHBOARD_URL") + "/home";
+      clearInterval(waitForDOMIntervalId);
+    }
+  }
   function init() {
     waitForDOMIntervalId = setInterval(function() {
       if (isDOMReady()) {
@@ -192,6 +201,8 @@ var Timeout = (function() {
         setLogoutLocation();
         //get expiration date/time to determine how long a session is?
         getSessionTokenInfo();
+        //on page load, check if token is not present?
+        handleNoToken();
         //assign id to the specific countdown timer id for this session
         initTimeoutIdentifier();
         //start count down


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180103470

Changes include:
- On page load, a check will be made to see if session token is present, if not, user will be re-directed to patient search dashboard page
- Move the timeout function call to when application DOM is mounted (The function call was previously made in the callback function for the ajax call to FHIR APIs.  The issue there is that a failed ajax call will resulted in the timeout function never being called)