### PR TITLE
bugfix - address syntax error for hiding section(s) in summary

### DIFF
--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -201,7 +201,7 @@ export default class Landing extends Component {
             sectionsToBeHidden.push(section);
           }
         });
-        if ((sectionsToBeHidden.length !== summaryMap[key]["sections"].length) && sectionsToBeHidden.length > 0) return true;
+        if ((sectionsToBeHidden.length !== summaryMap[key]["sections"].length) && sectionsToBeHidden.length > 0) continue;
       }
       //hide main section if any
       if (getEnv(`REACT_APP_SECTION_${key.toUpperCase()}`) === "hidden") {


### PR DESCRIPTION
Address syntax error that exits the loop prematurely for checking whether a section of a summary should be hidden