### PR TITLE
header - fix patient name cutoff issue as seen in Kent Prod 

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -60,10 +60,11 @@ export default class Header extends Component {
         </div>
         <div className="header__summary">
           <div className="header__summary-patient">
-            <FontAwesomeIcon className="patient-icon" icon="user-circle" title="patient" />
             <div className="patient-info">
-              <h1 className="patient-name">{patientName}</h1>
-
+              <div>
+                <FontAwesomeIcon className="patient-icon" icon="user-circle" title="patient" />
+                <h1 className="patient-name">{patientName}</h1>
+              </div>
               <div className="patient-demographics">
                 <span className="patient-dob" aria-label="Date of birth">DOB: {patientDOB}</span>
                 <span className="patient-gender">{patientGender}</span>

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -296,7 +296,7 @@ export default class Landing extends Component {
   }
 
   componentDidUpdate() {
-    const MIN_HEADER_HEIGHT = 92;
+    const MIN_HEADER_HEIGHT = 100;
     if (!this.tocInitialized && !this.state.loading && this.state.result) {
       tocbot.init({
         tocSelector: '.summary__nav',           // where to render the table of contents

--- a/src/styles/components/_Header.scss
+++ b/src/styles/components/_Header.scss
@@ -87,13 +87,12 @@
 
     &-patient {
       display: flex;
-      align-items: flex-start;
+      align-items: center;
       margin-left: 16px;
 
       .patient-icon {
         font-size: 1.6em;
         color: $color-blue;
-        margin-top: 4px;
         margin-right: 8px;
         position: relative;
       }
@@ -103,6 +102,7 @@
         line-height: 1em;
         font-size: 1.8em;
         margin: 0;
+        display: inline-block;
       }
 
       .patient-demographics {
@@ -124,7 +124,7 @@
       }
       .patient-info {
         padding-right: 8px;
-        min-width: 180px;
+        min-width: 240px;
       }
     }
 

--- a/src/styles/elements/_variables.scss
+++ b/src/styles/elements/_variables.scss
@@ -34,7 +34,7 @@ $color-warning: #df960e;
 $color-success: green;
 $link-color: darken($color-blue, 10%);
 $summary-nav-bg-color: #64707e;
-$min-header-height: 92px;
+$min-header-height: 100px;
 $summary-nav-width: 248px;
 // ------------------------- PATHS ----------------------------------------- //
 $fa-font-path: '/assets/fontawesome';


### PR DESCRIPTION
Address https://www.pivotaltracker.com/story/show/180606339
Patient name is cut off in header due to logo size

Fix includes:
- increase header size
- adjust styling for div element containing patient name

Example output after fix
![Screen Shot 2021-12-10 at 10 03 30 PM](https://user-images.githubusercontent.com/12942714/145666324-ac78276d-b34c-4a8a-9c5b-3aca5c013b89.png)

